### PR TITLE
chore: update image push condition to push for push events

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -144,7 +144,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ inputs.push-images == 'true'}}
+          push: ${{ inputs.push-images != 'false' }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE }}:${{ steps.prepare.outputs.version_release_tag }}
             ${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE }}:${{ steps.prepare.outputs.version }}


### PR DESCRIPTION
### Description
Fixes an issue where the docker build does not push image when coming from a push event