### PR TITLE
chore: update ubi to ubi9/nodejs-22-minimal:9.7-1763382208

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://registry.access.redhat.com/ubi9/nodejs-22
-FROM registry.access.redhat.com/ubi9/nodejs-22-minimal:9.6-1760544659
+FROM registry.access.redhat.com/ubi9/nodejs-22-minimal:9.7-1763382208
 
 # Runtime requirements and usage documentation
 LABEL description="RHDH Dynamic Plugin Factory - Build and package Backstage plugins" \


### PR DESCRIPTION
### Description

Updates the docker image UBI from ubi9/nodejs-22-minimal:9.6-1760544659 to ubi9/nodejs-22-minimal:9.7-1763382208
