### PR TITLE
chore: update documentation and default `repo-path` path for better clarity

### DIFF
--- a/.cursor/rules/documentation-standards.mdc
+++ b/.cursor/rules/documentation-standards.mdc
@@ -249,13 +249,6 @@ EOF
 - Align multi-line comments for readability
 - Use consistent comment block formatting
 
-## pdoc Documentation Rules
-- Use `pdoc` for API documentation generation from Python source
-- **Strictly use Google Style Docstrings** for all code elements
-- Document public variables using PEP 224 docstrings or `#:` doc-comments
-- Generated documentation located in `docs/sidekick/`
-- Target audience: developers and LLMs
-
 ## Google Style Docstring Format
 ```python
 def function_name(param1: str, param2: int) -> bool:

--- a/.cursor/rules/github-actions-workflow.mdc
+++ b/.cursor/rules/github-actions-workflow.mdc
@@ -1,0 +1,655 @@
+---
+description: Guidelines for maintaining GitHub Actions workflows and CI/CD configuration, including security best practices
+globs: .github/workflows/**,.github/actions/**,requirements*.txt
+---
+# GitHub Actions & CI/CD Standards
+
+## Workflow Awareness
+- The primary test workflow is located at `.github/workflows/test.yaml`.
+- The container build workflow is at `.github/workflows/build-container.yaml`.
+
+## Dependency Management
+- **Runtime Dependencies**: Add to `requirements.txt`.
+- **Test/Dev Dependencies**: Add to `requirements.dev.txt` (e.g., `pytest`, `ruff`, `mypy`).
+- **CI Consistency**: Ensure that `requirements.dev.txt` is installed in the CI test environment before running tests.
+
+## CI Steps
+When modifying `pytest` commands or adding new linting tools:
+1.  **Check Local First**: Ensure the command runs successfully locally.
+2.  **Update Workflow**: Reflect the exact arguments in `.github/workflows/test.yaml`.
+    - Example: If you add `--cov` to local pytest runs, update the CI step to include it or ensure `pytest.ini` handles it.
+
+## Linting in CI
+- CI enforces `ruff` and `mypy`.
+- Do not disable these checks in the workflow.
+- If you change the linter configuration (e.g., `ruff.toml` or `pyproject.toml`), ensure the CI workflow version of the tool is compatible.
+
+## Container Builds
+- If modifying `Dockerfile`, check `.github/workflows/build-container.yaml` to ensure build arguments and context remain valid.
+
+---
+
+# GitHub Workflows Security Best Practices
+
+This section provides comprehensive guidance for creating secure GitHub Actions workflows, based on the [GitHub Security Lab](https://securitylab.github.com/) blog series on GitHub Actions security.
+
+> **Note on Action Versions:** The action versions (commit SHAs and version tags) used in examples throughout this document may be outdated. When implementing these patterns, always check for the latest versions of actions and update the commit SHAs accordingly.
+
+## Table of Contents
+
+- [Untrusted Input Handling](#untrusted-input-handling)
+- [pull_request_target Security](#pull_request_target-security)
+- [Action Pinning and Permissions](#action-pinning-and-permissions)
+- [Environment Variable Safety](#environment-variable-safety)
+- [Artifact Security](#artifact-security)
+- [Repository-Specific Patterns](#repository-specific-patterns)
+- [Reusable Actions](#reusable-actions)
+
+---
+
+## Untrusted Input Handling
+
+Reference: [GitHub Actions: Untrusted Input](https://securitylab.github.com/resources/github-actions-untrusted-input/)
+
+### Always Use Environment Variables for GitHub Context Expressions
+
+**NEVER** directly interpolate GitHub context expressions in `run:` scripts. Always encapsulate them in environment variables first.
+
+```yaml
+# BAD - Direct interpolation is vulnerable to injection
+- name: Print PR title
+  run: echo "Title: ${{ github.event.pull_request.title }}"
+
+# GOOD - Use environment variable encapsulation
+- name: Print PR title
+  env:
+    TITLE: ${{ github.event.pull_request.title }}
+  run: echo "Title: $TITLE"
+```
+
+### Use Default GitHub Environment Variables
+
+Prefer using default GitHub environment variables (like `$GITHUB_REF_NAME`, `$GITHUB_SHA`, `$GITHUB_REPOSITORY`) over context expressions when available:
+
+```yaml
+# GOOD - Use default environment variables
+- name: Show branch info
+  run: |
+    echo "Branch: $GITHUB_REF_NAME"
+    echo "SHA: $GITHUB_SHA"
+    echo "Repository: $GITHUB_REPOSITORY"
+
+# Also acceptable when env vars aren't available
+- name: Show PR number
+  env:
+    PR_NUMBER: ${{ github.event.number }}
+  run: echo "PR #$PR_NUMBER"
+```
+
+### Dangerous Context Expressions
+
+The following context expressions are **especially dangerous** because they are controlled by external users:
+
+| Expression | Risk |
+|------------|------|
+| `github.event.issue.title` | Attacker-controlled issue title |
+| `github.event.issue.body` | Attacker-controlled issue body |
+| `github.event.pull_request.title` | Attacker-controlled PR title |
+| `github.event.pull_request.body` | Attacker-controlled PR description |
+| `github.event.comment.body` | Attacker-controlled comment content |
+| `github.event.review.body` | Attacker-controlled review content |
+| `github.event.pages.*.page_name` | Attacker-controlled page name |
+| `github.event.commits.*.message` | Attacker-controlled commit message |
+| `github.event.head_commit.message` | Attacker-controlled commit message |
+| `github.event.head_commit.author.email` | Attacker-controlled author email |
+| `github.event.head_commit.author.name` | Attacker-controlled author name |
+| `github.event.commits.*.author.email` | Attacker-controlled author email |
+| `github.event.commits.*.author.name` | Attacker-controlled author name |
+| `github.event.pull_request.head.ref` | Attacker-controlled branch name |
+| `github.event.pull_request.head.label` | Attacker-controlled label |
+| `github.event.pull_request.head.repo.default_branch` | Attacker-controlled default branch |
+| `github.head_ref` | Attacker-controlled branch name |
+
+**Always sanitize or encapsulate these in environment variables:**
+
+```yaml
+# GOOD - Proper encapsulation of dangerous inputs
+- name: Check PR eligibility
+  env:
+    PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+    PR_TITLE: ${{ github.event.pull_request.title }}
+  run: |
+    # Now safe to use in shell
+    echo "Branch: $PR_BRANCH"
+    echo "Title: $PR_TITLE"
+```
+
+---
+
+## pull_request_target Security
+
+Reference: [GitHub Actions: Preventing pwn requests](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)
+
+### When to Use Each Trigger
+
+| Trigger | Secrets Access | Write Permission | Use Case |
+|---------|---------------|------------------|----------|
+| `pull_request` | No (from forks) | No | Build/test PR code safely |
+| `pull_request_target` | Yes | Yes | Label PRs, comment, NO code checkout |
+| `workflow_run` | Yes | Yes | Post-processing after `pull_request` |
+
+### CRITICAL: Never Checkout Untrusted Code with pull_request_target
+
+```yaml
+# DANGEROUS - Checking out PR code with secrets access
+on: pull_request_target
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}  # UNSAFE!
+      - run: npm install  # Attacker's code runs with secrets!
+
+# SAFE - Only checkout target branch (default behavior)
+on: pull_request_target
+jobs:
+  label:
+    steps:
+      - uses: actions/checkout@v4  # Checks out base branch, safe
+      - name: Add label
+        run: gh pr edit $PR_NUMBER --add-label "needs-review"
+```
+
+### Preferred Pattern: pull_request + workflow_run
+
+When you need to run untrusted PR code AND access secrets/write permissions, split into two workflows:
+
+**Step 1: Unprivileged `pull_request` workflow**
+
+```yaml
+# .github/workflows/pr-build.yaml
+name: PR Build
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4  # Safe - no secrets access
+
+      - name: Build and test
+        run: |
+          npm install
+          npm test
+
+      - name: Save PR number
+        run: echo "${{ github.event.number }}" > pr_number.txt
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-results
+          path: |
+            pr_number.txt
+            test-results/
+```
+
+**Step 2: Privileged `workflow_run` workflow**
+
+```yaml
+# .github/workflows/pr-comment.yaml
+name: PR Comment
+on:
+  workflow_run:
+    workflows: ["PR Build"]
+    types: [completed]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(cat pr_number.txt)
+          gh pr comment "$PR_NUMBER" --body "Build succeeded!"
+```
+
+### When pull_request_target is Necessary: Use Author Verification
+
+If you must use `pull_request_target` with code checkout, verify the author is trusted:
+
+```yaml
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  check-commit-author:
+    runs-on: ubuntu-latest
+    outputs:
+      is_trusted: ${{ steps.check.outputs.is_trusted }}
+    steps:
+      - name: Checkout main branch for secure version of check action
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 1
+          ref: main  # Always use main branch for security-critical action
+          persist-credentials: false
+
+      - name: Check if author is trusted
+        id: check
+        env:
+          AUTHOR: ${{ github.actor }}
+        run: |
+          # Implement your author verification logic here
+          # Example: check against a list of trusted contributors
+          echo "is_trusted=false" >> $GITHUB_OUTPUT
+
+  authorize:
+    environment:
+      ${{ (needs.check-commit-author.outputs.is_trusted == 'true' ||
+          github.event.pull_request.head.repo.full_name == github.repository) &&
+          'internal' || 'external' }}
+    runs-on: ubuntu-latest
+    needs: check-commit-author
+    steps:
+      - name: Authorized
+        run: echo "Author is authorized to run this workflow"
+
+  build:
+    needs: authorize
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR code (now safe after authorization)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+```
+
+---
+
+## Action Pinning and Permissions
+
+Reference: [GitHub Actions: Building Blocks](https://securitylab.github.com/resources/github-actions-building-blocks/)
+
+### Pin Actions to Commit SHAs
+
+**Always** pin third-party actions to full commit SHAs, not tags:
+
+```yaml
+# BAD - Tags can be moved to malicious commits
+- uses: actions/checkout@v4
+- uses: docker/login-action@v3
+
+# GOOD - Pinned to immutable commit SHA with version comment
+- uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+- uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
+```
+
+### Use persist-credentials: false
+
+Always disable credential persistence unless explicitly needed:
+
+```yaml
+- uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+  with:
+    persist-credentials: false  # Prevents token from being stored on disk
+```
+
+### Explicit Permissions Block
+
+Always declare the minimum required permissions:
+
+```yaml
+# At workflow level
+permissions:
+  contents: read
+  pull-requests: write
+
+# Or at job level for finer control
+jobs:
+  build:
+    permissions:
+      contents: read
+    # ...
+
+  deploy:
+    permissions:
+      contents: read
+      packages: write
+    # ...
+```
+
+### Common Permission Patterns
+
+```yaml
+# Read-only workflow (most restrictive)
+permissions:
+  contents: read
+
+# PR workflows that need to comment
+permissions:
+  contents: read
+  pull-requests: write
+
+# Package publishing
+permissions:
+  contents: read
+  packages: write
+
+# Release workflows
+permissions:
+  contents: write
+  packages: write
+```
+
+---
+
+## Environment Variable Safety
+
+Reference: [GitHub Actions: New Patterns and Mitigations](https://securitylab.github.com/resources/github-actions-new-patterns-and-mitigations/)
+
+### NEVER Append Untrusted Data to GITHUB_ENV
+
+Allowing arbitrary input to be written to `$GITHUB_ENV` is extremely dangerous. Attackers can poison special environment variables that affect subsequent step execution.
+
+```yaml
+# DANGEROUS - Allows command injection via GITHUB_ENV
+- name: Set environment
+  run: |
+    echo "BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV  # UNSAFE!
+
+# SAFE - Use env: block instead
+- name: Use branch
+  env:
+    BRANCH: ${{ github.head_ref }}
+  run: echo "Branch is $BRANCH"
+```
+
+### BASH_ENV Poisoning Attack
+
+**CRITICAL:** If an attacker can write arbitrary content to `$GITHUB_ENV`, they can set `BASH_ENV` to execute code **before** subsequent Bash steps run:
+
+```bash
+# Attack vector - if attacker controls input that gets written to GITHUB_ENV:
+echo 'BASH_ENV=$(malicious_command 1>&2)' >> $GITHUB_ENV
+# Or point to a malicious script:
+echo 'BASH_ENV=/path/to/attacker/script.sh' >> $GITHUB_ENV
+```
+
+When the next step runs, Bash will execute the `BASH_ENV` value before running the step's commands.
+
+> **Note:** GitHub Actions runners execute `run:` statements using `bash --noprofile --norc -e -o pipefail {0}`, which does NOT load `.bashrc`, `.bash_profile`, or `.initrc`. However, `BASH_ENV` is still evaluated.
+
+### Other Dangerous Environment Variables
+
+Beyond `BASH_ENV`, attackers can poison other runtime-specific variables such as in this non-exhaustible list:
+
+| Variable | Risk |
+|----------|------|
+| `BASH_ENV` | Executed before each Bash shell step |
+| `NODE_OPTIONS` | Injects options/requires into Node.js processes |
+| `PERL5OPT` | Injects options into Perl processes |
+| `RUBYOPT` | Injects options into Ruby processes |
+| `PYTHONSTARTUP` | Script executed on Python interpreter startup |
+| `LD_PRELOAD` | Loads shared libraries before others (Linux) |
+
+**Never allow untrusted input to set variables via `$GITHUB_ENV`.**
+
+### Safe GITHUB_ENV Usage
+
+Only write trusted, validated data to `GITHUB_ENV`:
+
+```yaml
+# SAFE - Writing computed/validated values
+- name: Compute values
+  run: |
+    # Safe - internally computed values
+    SHORT_SHA="${GITHUB_SHA:0:7}"
+    echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
+
+    # Safe - output from trusted command
+    DATE=$(date +%Y-%m-%d)
+    echo "BUILD_DATE=$DATE" >> $GITHUB_ENV
+```
+
+### Use GITHUB_OUTPUT for Step Outputs
+
+```yaml
+- name: Generate output
+  id: compute
+  env:
+    INPUT_VALUE: ${{ github.event.inputs.value }}
+  run: |
+    # Process the input safely
+    result=$(echo "$INPUT_VALUE" | tr '[:upper:]' '[:lower:]')
+    echo "result=$result" >> $GITHUB_OUTPUT
+
+- name: Use output
+  run: echo "Result: ${{ steps.compute.outputs.result }}"
+```
+
+---
+
+## Artifact Security
+
+### Treat Artifacts from Untrusted Sources as Untrusted
+
+When using `workflow_run` to process artifacts from `pull_request` workflows:
+
+```yaml
+on:
+  workflow_run:
+    workflows: ["PR Build"]
+    types: [completed]
+
+jobs:
+  process:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # DANGEROUS - Never execute downloaded binaries
+      # - run: ./downloaded-binary
+
+      # DANGEROUS - NEVER write artifact contents to GITHUB_ENV
+      # Attackers can craft artifact content to hijack environment variables
+      # and inject arbitrary commands via multiline values
+      # - run: echo "DATA=$(cat result.txt)" >> $GITHUB_ENV  # UNSAFE!
+
+      # SAFE - Only read data files and validate contents
+      - name: Read PR number
+        run: |
+          PR_NUMBER=$(cat pr_number.txt)
+          # Validate it's actually a number
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "Invalid PR number"
+            exit 1
+          fi
+```
+
+### Validate Artifact Contents
+
+**CRITICAL:** Never write artifact contents directly to `GITHUB_ENV`. Attackers can craft malicious artifact content with multiline values that hijack environment variables and inject arbitrary shell commands in subsequent steps.
+
+```yaml
+- name: Process artifact safely
+  run: |
+    # Validate file exists and is reasonable size
+    if [[ ! -f "result.txt" ]] || [[ $(stat -c%s "result.txt") -gt 1000000 ]]; then
+      echo "Invalid artifact"
+      exit 1
+    fi
+
+    # Read and validate content - use in current step only
+    CONTENT=$(cat result.txt)
+    # Add validation as needed
+
+    # NEVER do this with artifact content:
+    # echo "CONTENT=$CONTENT" >> $GITHUB_ENV  # UNSAFE - allows env hijacking!
+```
+
+---
+
+## Repository-Specific Patterns
+
+### Concurrency Control
+
+Use concurrency to cancel duplicate runs **from the same PR or branch only**. A new push to PR A should cancel the previous workflow for PR A, but should NOT affect workflows for PR B.
+
+```yaml
+concurrency:
+  # Group by workflow name + PR number (for PRs) or ref (for branches)
+  # This ensures:
+  #   - PR A's new workflow cancels PR A's old workflow
+  #   - PR A's workflow does NOT cancel PR B's workflow
+  #   - Push to branch X cancels previous push to branch X
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+```
+
+**How the group key works:**
+- For pull requests: `github.event.number` provides the unique PR number (e.g., `my-workflow-123`)
+- For branch pushes: `github.ref` provides the branch ref (e.g., `my-workflow-refs/heads/main`)
+- Each unique group runs independently; only duplicate runs within the same group are cancelled
+
+### Standard Workflow Header
+
+```yaml
+name: Descriptive Workflow Name
+
+on:
+  pull_request:  # Or appropriate trigger
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # Global environment variables
+  REGISTRY: quay.io
+
+jobs:
+  # ...
+```
+
+### Environment-Based Authorization
+
+Use GitHub Environments for manual approval gates if `pull_request_target` cannot be avoided:
+
+```yaml
+jobs:
+  authorize:
+    environment:
+      ${{ (condition) && 'internal' || 'external' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Authorized"
+
+  deploy:
+    needs: authorize
+    # Proceeds only after environment approval
+```
+
+---
+
+## Reusable Actions
+
+### When to Create Reusable Actions
+
+Create a reusable composite action in `.github/actions/` when:
+
+1. Logic is used by multiple workflows
+2. Logic is complex enough to benefit from encapsulation
+3. Logic requires multiple steps that should be tested together
+
+### Composite Action Template
+
+```yaml
+# .github/actions/my-action/action.yaml
+name: "My Action"
+description: "Description of what this action does"
+
+inputs:
+  required-input:
+    description: "A required input"
+    required: true
+  optional-input:
+    description: "An optional input"
+    required: false
+    default: "default-value"
+
+outputs:
+  result:
+    description: "The result of the action"
+    value: ${{ steps.main.outputs.result }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        INPUT_VALUE: ${{ inputs.required-input }}
+      run: |
+        if [[ -z "$INPUT_VALUE" ]]; then
+          echo "Error: required-input is empty"
+          exit 1
+        fi
+
+    - name: Main logic
+      id: main
+      shell: bash
+      env:
+        REQUIRED: ${{ inputs.required-input }}
+        OPTIONAL: ${{ inputs.optional-input }}
+      run: |
+        # Your logic here
+        echo "result=success" >> $GITHUB_OUTPUT
+```
+
+---
+
+## Quick Reference Checklist
+
+When creating or reviewing a workflow, verify:
+
+- [ ] All GitHub context expressions are encapsulated in `env:` blocks
+- [ ] No direct interpolation of untrusted inputs in `run:` scripts
+- [ ] Actions are pinned to commit SHAs with version comments
+- [ ] `permissions:` block is explicit and minimal
+- [ ] `persist-credentials: false` used with `actions/checkout` where appropriate
+- [ ] `pull_request_target` is only used when secrets/write access is truly needed
+- [ ] If `pull_request_target` checks out PR code, author verification is in place
+- [ ] No untrusted data is appended to `GITHUB_ENV` (especially `BASH_ENV`, `NODE_OPTIONS`, etc.)
+- [ ] Artifacts from untrusted sources are validated before use
+- [ ] Concurrency is configured to prevent duplicate runs
+
+---
+
+## References
+
+- [Part 1: Preventing pwn requests](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)
+- [Part 2: Untrusted Input](https://securitylab.github.com/resources/github-actions-untrusted-input/)
+- [Part 3: Building Blocks](https://securitylab.github.com/resources/github-actions-building-blocks/)
+- [Part 4: New Patterns and Mitigations](https://securitylab.github.com/resources/github-actions-new-patterns-and-mitigations/)

--- a/.cursor/rules/integration-tests.mdc
+++ b/.cursor/rules/integration-tests.mdc
@@ -1,0 +1,171 @@
+---
+description: Standards for writing integration tests for RHDH Dynamic Plugin Factory
+globs: tests/test_*.py, tests/e2e/*.py
+---
+# Integration & E2E Testing Standards
+
+## Definitions
+1.  **Component Integration Tests**: Verify interaction between Python components (Config, CLI, File System) using real file operations but mocked external heavy lifters (git, registry).
+2.  **Container E2E Tests**: Verify the end-to-end workflow by building the container image and running it against example configurations.
+
+## Markers
+- `@pytest.mark.integration`: For component integration tests.
+- `@pytest.mark.e2e`: For container-based end-to-end tests.
+
+Ensure `pytest.ini` includes these markers:
+```ini
+markers =
+    integration: Component integration tests
+    e2e: End-to-end container tests
+```
+
+## Component Integration Tests
+- **Location**: `tests/` (alongside unit tests or in `tests/integration/`).
+- **Principle**: Use `tmp_path` for all file I/O.
+- **Scope**: Test `cli.main()` or `PluginFactoryConfig` flows with realistic directory structures created by `setup_test_env`.
+
+### Using the Factory Fixture for Integration Tests
+The `make_config` factory fixture simplifies creating `PluginFactoryConfig` instances with overrides:
+
+```python
+@pytest.mark.integration
+def test_full_config_flow(self, make_config):
+    """Test a complete configuration workflow."""
+    config = make_config(
+        registry_url="quay.io",
+        registry_namespace="test-namespace",
+        registry_username="test-user",
+        registry_password="test-password"
+    )
+    # Config is fully set up with realistic directories
+    assert config.rhdh_cli_version == "1.7.2"
+    assert config.registry_url == "quay.io"
+```
+
+## Container E2E Tests
+
+> **Note:** E2E tests are not yet implemented. The `tests/e2e/` directory does not exist. The following guidance is for future implementation.
+
+- **Location**: `tests/e2e/`.
+- **Goal**: Validate that the container image works correctly with the provided `examples/`.
+- **Workflow**:
+    1.  **Get Image**: Use a pre-built image from the registry (CI) or build locally (development).
+    2.  **Run**: Execute the container mounting a `tmp_path` copy of an `examples/` directory.
+    3.  **Verify**: Check the output directory (mounted volume) for expected artifacts (e.g., `.tgz` files, `plugins-list.yaml`).
+
+### Image Source Strategy
+
+E2E tests support two modes controlled by environment variables:
+
+| Mode | Environment Variable | Use Case |
+|------|---------------------|----------|
+| **CI (default)** | `E2E_IMAGE` | Test against pre-built image from registry |
+| **Local build** | `E2E_BUILD_LOCAL=true` | Test Dockerfile changes before pushing |
+
+**Published Image Tags:**
+
+The container image is published to `quay.io/rhdh-community/dynamic-plugins-factory`:
+
+| Context | Tag Pattern | Example |
+|---------|-------------|---------|
+| Pull Requests | `pr-{number}-{short_sha}`. `pr-{number}` | `pr-123-abc1234`, `pr-123` |
+| Main branch | `{short_sha}` | `abc1234` |
+| Releases | `{version}-{release}`, `{version}`, `latest` | `1.8-0`, `1.8`, `latest` |
+
+### E2E Fixture Pattern
+
+```python
+import os
+import pytest
+import subprocess
+import shutil
+
+@pytest.fixture(scope="session")
+def factory_image():
+    """Get or build the factory image for E2E tests.
+    
+    Modes:
+    - CI (default): Uses E2E_IMAGE env var or falls back to latest
+    - Local: Set E2E_BUILD_LOCAL=true to build locally
+    
+    Returns:
+        str: The image tag to use for tests
+    """
+    if os.environ.get("E2E_BUILD_LOCAL") == "true":
+        # Local development: build image
+        tag = "rhdh-factory:local"
+        subprocess.run(["podman", "build", "-t", tag, "."], check=True)
+        return tag
+    
+    # CI/Default: use pre-built image
+    return os.environ.get(
+        "E2E_IMAGE",
+        "quay.io/rhdh-community/dynamic-plugins-factory:latest"
+    )
+
+@pytest.mark.e2e
+def test_example_config_aws_ecs(factory_image, tmp_path):
+    # Setup: Copy example to tmp_path
+    example_dir = tmp_path / "example"
+    shutil.copytree("examples/example-config-aws-ecs", example_dir)
+    
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    # Action: Run container
+    subprocess.run([
+        "podman", "run", "--rm",
+        "-v", f"{example_dir}:/config:z",
+        "-v", f"{output_dir}:/outputs:z",
+        factory_image
+    ], check=True)
+
+    # Assertion: Check outputs
+    assert (output_dir / "plugins-list.yaml").exists()
+```
+
+### Running E2E Tests
+
+```bash
+# Test against latest published image (default)
+pytest tests/e2e/ -m e2e
+
+# Test against specific version
+E2E_IMAGE=quay.io/rhdh-community/dynamic-plugins-factory:1.8-0 pytest tests/e2e/ -m e2e
+
+# Test against a PR image
+E2E_IMAGE=quay.io/rhdh-community/dynamic-plugins-factory:pr-123-abc1234 pytest tests/e2e/ -m e2e
+
+# Test with local build (for Dockerfile changes)
+E2E_BUILD_LOCAL=true pytest tests/e2e/ -m e2e
+```
+
+### CI Workflow Integration
+
+**For Pull Requests:**
+```yaml
+- name: Run E2E Tests
+  env:
+    E2E_IMAGE: quay.io/rhdh-community/dynamic-plugins-factory:pr-${{ github.event.number }}-${{ steps.prepare.outputs.short_sha }}
+  run: pytest tests/e2e/ -m e2e
+```
+
+**For Main Branch:**
+```yaml
+- name: Run E2E Tests
+  env:
+    E2E_IMAGE: quay.io/rhdh-community/dynamic-plugins-factory:${{ steps.prepare.outputs.short_sha }}
+  run: pytest tests/e2e/ -m e2e
+```
+
+## Available Fixtures for Integration Tests
+
+The following fixtures from `tests/conftest.py` are particularly useful for integration tests:
+
+| Fixture | Description |
+|---------|-------------|
+| `setup_test_env` | Complete test environment with `config/`, `source/` dirs, `source.json`, `plugins-list.yaml`, and env vars |
+| `make_config` | Factory fixture to create `PluginFactoryConfig` with sensible defaults and easy overrides |
+| `temp_workspace` | Temporary workspace directory with realistic plugin structure |
+| `valid_default_env` | Loads environment variables from the real `default.env` file |
+| `clean_env` | Pristine environment with all relevant env vars removed |

--- a/.cursor/rules/pytest-unit-tests.mdc
+++ b/.cursor/rules/pytest-unit-tests.mdc
@@ -1,0 +1,91 @@
+---
+description: Standards and best practices for writing Pytest unit tests in this repository
+globs: tests/test_*.py
+---
+# Pytest Unit Testing Standards
+
+## General Principles
+- All unit tests must reside in the `tests/` directory.
+- Use **class-based grouping** for tests (e.g., `class TestClassName:`).
+- One test file per module (e.g., `test_config.py` for `config.py`).
+- Ensure **100% isolation**: No network calls, no real file system changes outside `tmp_path`, no system command execution.
+
+## Test Structure
+```python
+import pytest
+from unittest.mock import patch, MagicMock
+from src.rhdh_dynamic_plugin_factory.module import TargetClass
+
+class TestTargetClassMethod:
+    """Tests for TargetClass.method."""
+
+    def test_method_happy_path(self, mock_args, setup_test_env):
+        """Test description."""
+        # Setup
+        ...
+        # Action
+        ...
+        # Assertion
+        ...
+```
+
+## Fixture Usage
+Leverage existing fixtures in `tests/conftest.py` instead of recreating them:
+- `mock_logger`: Returns a MagicMock logger to suppress/verify logs.
+- `mock_args(tmp_path)`: Returns an `argparse.Namespace` with valid default CLI arguments.
+- `valid_default_env(monkeypatch)`: Loads environment variables from the real `default.env` file.
+- `valid_source_json(tmp_path)`: Creates and returns a valid `source.json` Path object.
+- `valid_plugins_list_yaml(tmp_path)`: Creates and returns a valid `plugins-list.yaml` Path object.
+- `temp_workspace(tmp_path)`: Creates a temporary workspace directory with realistic structure including sample plugin.
+- `setup_test_env(tmp_path, monkeypatch)`: Sets up a complete test environment with `config/` and `source/` directories, required files, and environment variables.
+- `clean_env(monkeypatch)`: Removes all relevant environment variables for a pristine environment.
+- `make_config(setup_test_env)`: **Factory fixture** to create `PluginFactoryConfig` instances with sensible defaults and easy overrides.
+
+## Mocking Standards
+- Use `unittest.mock.patch` for all external dependencies.
+- **Strictly mock** `subprocess.run`, `git` commands, and network requests.
+- Use `monkeypatch` (pytest fixture) for environment variables.
+
+### Example: Mocking Subprocess
+```python
+def test_subprocess_call(self, mock_args):
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        # ... call code ...
+        mock_run.assert_called_once()
+```
+
+## Environment Variables
+- Use the `monkeypatch` fixture to set environment variables.
+- Alternatively, use `clean_env` if you need a pristine environment.
+- Use `valid_default_env` to load the actual `default.env` file values.
+
+```python
+def test_env_var(self, monkeypatch):
+    monkeypatch.setenv("RHDH_CLI_VERSION", "1.0.0")
+    # ...
+```
+
+## Factory Fixture Pattern
+Use the `make_config` factory fixture for creating `PluginFactoryConfig` instances with easy overrides:
+
+```python
+def test_with_registry_config(self, make_config):
+    """Test using factory fixture with overrides."""
+    config = make_config(
+        registry_url="quay.io",
+        registry_namespace="test-namespace"
+    )
+    # config has all defaults plus the overrides
+    assert config.registry_url == "quay.io"
+```
+
+## Naming Conventions
+- Files: `test_<module_name>.py`
+- Classes: `Test<ClassName><MethodName>` (optional MethodName if grouping by method)
+- Functions: `test_<scenario_description>`
+
+## Current Test Files
+- `test_config.py`: Tests for `PluginFactoryConfig` class (load_from_env, load_registry_config, apply_patches_and_overlays, export_plugins)
+- `test_source_config.py`: Tests for `SourceConfig` class (from_file, clone_to_path)
+- `test_plugin_list_config.py`: Tests for `PluginListConfig` class (from_file, get_plugins, add_plugin, remove_plugin)

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 
 # Local Configuration Folders
 config/
-workspace/
+source/
 outputs/
 
 # VSCode
@@ -14,3 +14,6 @@ outputs/
 **/htmlcov/
 **/.coverage
 **/.coverage.*
+
+# Logs
+**/*.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Run the factory with your local build:
 podman run --rm -it \
   --device /dev/fuse \
   -v ./config:/config:z \
-  -v ./workspace:/workspace:z \
+  -v ./source:/source:z \
   -v ./outputs:/outputs:z \
   rhdh-dynamic-plugin-factory:dev \
   --workspace-path workspaces/todo \
@@ -163,7 +163,7 @@ The factory will automatically read the registry credentials from `./config/.env
 ```bash
 python -m src.rhdh_dynamic_plugin_factory \
   --config-dir ./config \
-  --repo-path ./existing-workspace \
+  --repo-path ./source \
   --workspace-path . \
   --output-dir ./outputs \
   --use-local
@@ -318,9 +318,6 @@ pytest tests/
 
 # Check code coverage
 pytest tests/ --cov=src/rhdh_dynamic_plugin_factory --cov-report=term-missing
-
-# Format code (if using black)
-black src/ tests/
 
 # Check types (if using mypy)
 mypy src/

--- a/examples/example-config-aws-ecs/README.md
+++ b/examples/example-config-aws-ecs/README.md
@@ -122,13 +122,13 @@ From the repository root, run:
 python -m src.rhdh_dynamic_plugin_factory \
   --config-dir ./examples/example-config-aws-ecs \
   --workspace-path . \
-  --repo-path ./workspace \
+  --repo-path ./source \
   --output-dir ./outputs
 ```
 
 This will do the following:
 
-1. The factory clones the AWS plugins repository to `./workspace`
+1. The factory clones the AWS plugins repository to `./source`
 2. The `1-avoid-double-wildcards.patch` is applied to fix workspace configuration
 3. Dependencies are installed at the repository root
 4. Frontend and backend ECS plugins are compiled
@@ -138,7 +138,7 @@ This will do the following:
 
 ## Expected Output
 
-After successful execution, you'll find these files in `./outputs/`:
+After successful execution, you'll find these files in `./outputs`:
 
 ```bash
 outputs/

--- a/examples/example-config-gitlab/README.md
+++ b/examples/example-config-gitlab/README.md
@@ -51,7 +51,7 @@ The overlay directory structure mirrors the plugin's source structure. Files in 
 ### How Overlays Work
 
 1. The factory clones the source repository
-2. Before building, it copies files from `config/<plugin-path>/overlay/` to the corresponding paths in `workspace/<plugin-path>/`
+2. Before building, it copies files from `config/<plugin-path>/overlay/` to the corresponding paths in `<workspace-path>/<plugin-path>/`
 3. The overlaid files replace the original files completely if one exists, otherwise it will add the file
 4. The modified source is then built and exported
 
@@ -68,7 +68,7 @@ podman run --rm -it \
   --device /dev/fuse \
   -v ./examples/example-config-gitlab:/config:z \
   -v ./outputs:/outputs:z \
-  -f ./workspace:/workspace:z \
+  -f ./source:/source:z \
   quay.io/rhdh-community/dynamic-plugins-factory:latest \
   --workspace-path .
 ```
@@ -83,21 +83,22 @@ From the repository root, run:
 python -m src.rhdh_dynamic_plugin_factory \
   --config-dir ./examples/example-config-gitlab \
   --workspace-path . \
+  --repo-path ./source \
   --output-dir ./outputs
 ```
 
 This will do the following:
 
-1. The factory clones the GitLab plugin repository to `./workspace`
-2. Custom `bundle.ts` and `index.ts` files are copied to `./workspace/packages/gitlab-backend/src/`
-3. Dependencies are installed at the repository root
+1. The factory clones the GitLab plugin repository to `./source`
+2. Custom `bundle.ts` and `index.ts` files are copied to `./source/packages/gitlab-backend/src/`
+3. Dependencies are installed at the repository source
 4. Both frontend and backend plugins are compiled
 5. Plugins are exported as dynamic plugins using the RHDH CLI
 6. Plugin tarballs and integrity files are created in `./outputs`
 
 ## Expected Output
 
-After successful execution, you'll find these files in `./outputs/`:
+After successful execution, you'll find these files in `./outputs`:
 
 ```bash
 outputs/

--- a/examples/example-config-todo/README.md
+++ b/examples/example-config-todo/README.md
@@ -67,14 +67,14 @@ From the repository root, run:
 ```bash
 python -m src.rhdh_dynamic_plugin_factory \
   --config-dir ./examples/example-config-todo \
-  --repo-path ./workspace \
+  --repo-path ./source \
   --workspace-path workspaces/todo \
   --output-dir ./outputs
 ```
 
 This will do the following:
 
-1. The factory clones the Backstage Community Plugins repository to `./workspace`
+1. The factory clones the Backstage Community Plugins repository to `./source`
 2. The custom `scalprum-config.json` is overlaid on top of the plugin source directory
 3. Dependencies are installed in the TODO workspace
 4. Both frontend and backend plugins are exported and packaged using the RHDH CLI with the arguments defined in `./config/plugins-list.yaml` which in this case is no additional arguments
@@ -82,7 +82,7 @@ This will do the following:
 
 ## Expected Output
 
-After successful execution, you'll find these files in `./outputs/`:
+After successful execution, you'll find these files in `./outputs`:
 
 ```bash
 outputs/

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,9 @@
-# Development dependencies (optional)
-pytest>=7.0.0
-pytest-cov>=4.0.0
-mypy>=1.0.0
-ruff>=0.1.0
+# Development and testing dependencies
+-r requirements.txt
+
+coverage==7.13.1
+mypy==1.19.1
+pytest==9.0.2
+pytest-cov==7.0.0
+ruff==0.14.10
+types-PyYAML==6.0.12.20250915

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Core dependencies
-pyyaml>=6.0
-python-dotenv>=1.0.0
-rich>=13.0.0
+# Core runtime dependencies
+PyYAML==6.0.3
+python-dotenv==1.1.1
+rich==14.1.0

--- a/src/rhdh_dynamic_plugin_factory/config.py
+++ b/src/rhdh_dynamic_plugin_factory/config.py
@@ -23,9 +23,9 @@ class PluginFactoryConfig:
     # Required fields loaded from default.env file (can be overridden by environment variables)
     rhdh_cli_version: str = field(default="")
     
-    # Directories
-    repo_path: str = field(default="/workspace")  # Local path where plugin source code will be stored
+    repo_path: str = field(default="/source")  # Local path where plugin source code will be stored
     config_dir: str = field(default="/config")
+    workspace_path: str = field(default="")  # Relative path from repo_path to the workspace
     
     # Registry configuration (loaded from environment variables, only required for push operations)
     registry_url: Optional[str] = field(default=None)
@@ -34,10 +34,7 @@ class PluginFactoryConfig:
     registry_namespace: Optional[str] = field(default=None)
     registry_insecure: bool = field(default=False)
 
-    # Logging
     log_level: str = field(default="INFO")
-    
-    # Local repository flag
     use_local: bool = field(default=False)
 
     logger = get_logger("config")
@@ -52,10 +49,8 @@ class PluginFactoryConfig:
             env_file: Optional additional .env file to merge with defaults
         """
         
-        # Create config with environment overrides
         config = cls()
         
-        # First, load default.env if it exists
         default_env_path = Path(__file__).parent.parent.parent / "default.env"
         
         config.logger.debug(f'[bold blue]Loading environment variables from {default_env_path}[/bold blue]')
@@ -64,27 +59,18 @@ class PluginFactoryConfig:
             load_dotenv(default_env_path)
             config.logger.debug(f'[green]✓ Loaded {default_env_path}[/green]')
             
-        # Then load additional env file if specified and exists
         if env_file and env_file.exists():
             load_dotenv(env_file, override=True)
             config.logger.debug(f'[green]✓ Loaded {env_file}[/green]')
 
-        config.logger.debug(f'[bold blue]Loading configuration from environment variables and CLI arguments[/bold blue]')
+        config.logger.debug('[bold blue]Loading configuration from environment variables and CLI arguments[/bold blue]')
         
-        try:
-            config.workspace_path = Path(os.getenv("WORKSPACE_PATH", args.workspace_path))
-            config.logger.debug(f'[green]✓ Relative workspace path set to {config.workspace_path}[/green]')
-        except Exception as e:
-            config.logger.error(f"[red]Failed to set workspace path, please set WORKSPACE_PATH environment variable or use the --workspace-path argument: {e}[/red]")
-            sys.exit(1)
+        config.workspace_path = os.getenv("WORKSPACE_PATH", args.workspace_path)
+        config.config_dir = args.config_dir
+        config.repo_path = args.repo_path
         
-        config.config_dir = Path(args.config_dir)
-        config.repo_path = Path(args.repo_path)
-        
-        # Load version defaults from environment (set by default.env)
-        config.rhdh_cli_version = os.getenv("RHDH_CLI_VERSION")
+        config.rhdh_cli_version = os.getenv("RHDH_CLI_VERSION", "")
 
-        # Load registry configuration from environment variables
         config.registry_url = os.getenv("REGISTRY_URL")
         config.registry_username = os.getenv("REGISTRY_USERNAME")
         config.registry_password = os.getenv("REGISTRY_PASSWORD")
@@ -93,24 +79,22 @@ class PluginFactoryConfig:
 
         config.log_level = os.getenv("LOG_LEVEL", args.log_level)
         
-        # Load use_local flag from args
         config.use_local = args.use_local
         
-        # Validate and create required directories
         dirs_to_create = [config.config_dir, config.repo_path]
         for dir_path in dirs_to_create:
-            dir_path.mkdir(parents=True, exist_ok=True)
+            os.makedirs(dir_path, exist_ok=True)
         
-        # Validate required version fields
         if not config.rhdh_cli_version:
             raise ValueError("RHDH_CLI_VERSION must be set (usually loaded from default.env)")
         
-        # Validate log level
+        if not config.workspace_path:
+            raise ValueError("WORKSPACE_PATH must be set via environment variable or --workspace-path argument")
+        
         valid_log_levels = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
         if config.log_level.upper() not in valid_log_levels:
             raise ValueError(f"Invalid log level: {config.log_level}")
         
-        # Validate source.json and plugins-list.yaml
         config._validate_source_json()
         config._validate_plugins_list()
         
@@ -126,19 +110,16 @@ class PluginFactoryConfig:
             self.logger.info("Skipping registry configuration (not pushing images)")
             return
             
-        # Validate required registry configuration for push operations
         if not self.registry_url:
             raise ValueError("REGISTRY_URL environment variable is required when --push-images is enabled")
         
         if not self.registry_namespace:
             raise ValueError("REGISTRY_NAMESPACE environment variable is required when --push-images is enabled")
         
-        # Validate registry credentials are required for push operations
         if not self.registry_username or not self.registry_password:
             raise ValueError("REGISTRY_USERNAME and REGISTRY_PASSWORD environment variables are required when --push-images is enabled")
         ## TODO: Add support for token logins for ghcr.io registry as well
 
-        # Attempt buildah login with credentials
         try:
             cmd = [
                 "buildah", "login",
@@ -146,7 +127,6 @@ class PluginFactoryConfig:
                 "--password", str(self.registry_password)
             ]
             
-            # Add insecure flag if needed
             if self.registry_insecure:
                 cmd.extend(["--tls-verify=false"])
                 
@@ -166,11 +146,10 @@ class PluginFactoryConfig:
     
     def _validate_source_json(self) -> None:
         """Validate source.json file existence and repo_path state."""
-        source_file = self.config_dir / "source.json"
+        source_file = os.path.join(self.config_dir, "source.json")
         
-        if not source_file.exists():
-            # Check if repo_path is empty
-            if not self.repo_path.exists() or not any(self.repo_path.iterdir()):
+        if not os.path.exists(source_file):
+            if not os.path.exists(self.repo_path) or not os.listdir(self.repo_path):
                 raise ValueError(
                     f"source.json not found at {source_file} and {self.repo_path} is empty. "
                     "Please provide source.json to clone a repository or use --use-local with a locally mounted repository."
@@ -184,9 +163,9 @@ class PluginFactoryConfig:
     
     def _validate_plugins_list(self) -> None:
         """Validate plugins-list.yaml file existence."""
-        plugins_file = self.config_dir / "plugins-list.yaml"
+        plugins_file = os.path.join(self.config_dir, "plugins-list.yaml")
         
-        if not plugins_file.exists():
+        if not os.path.exists(plugins_file):
             self.logger.warning(
                 f"plugins-list.yaml not found at {plugins_file}. Will attempt to auto-generate after repository is available."
             )
@@ -201,26 +180,26 @@ class PluginFactoryConfig:
         - The plugins are located in the plugins/* directory
         - `workspace_path` is the path to the workspace from the root of the repository
         """
-        plugins_file = self.config_dir / "plugins-list.yaml"
+        plugins_file = os.path.join(self.config_dir, "plugins-list.yaml")
         
-        if plugins_file.exists():
+        if os.path.exists(plugins_file):
             self.logger.debug(f"[green]✓ plugins-list.yaml already exists at {plugins_file}. Skipping auto-generation.[/green]")
             return True
         
         self.logger.info("[bold blue]Auto-generating plugins-list.yaml[/bold blue]")
         
         try:
-            if not self.repo_path.exists():
+            if not os.path.exists(self.repo_path):
                 self.logger.error(f"[red]Repository does not exist at {self.repo_path}[/red]")
                 return False
-            workspace_path = self.repo_path.joinpath(self.workspace_path).absolute()
-            if not workspace_path.exists():
-                self.logger.error(f"[red]Workspace does not exist at {workspace_path}[/red]")
+            workspace_full_path = os.path.abspath(os.path.join(self.repo_path, self.workspace_path))
+            if not os.path.exists(workspace_full_path):
+                self.logger.error(f"[red]Workspace does not exist at {workspace_full_path}[/red]")
                 return False
             
             # TODO: Implement PluginListConfig.create_default function
-            plugin_cfg = PluginListConfig.create_default(workspace_path=workspace_path)
-            plugin_cfg.to_file(plugins_file)
+            plugin_cfg = PluginListConfig.create_default(workspace_path=Path(workspace_full_path))
+            plugin_cfg.to_file(Path(plugins_file))
             
             plugins = plugin_cfg.get_plugins()
             if plugins:
@@ -238,17 +217,17 @@ class PluginFactoryConfig:
     
     def discover_source_config(self) -> Optional["SourceConfig"]:
         """Discovers and loads source configuration from config_dir/source.json."""
-        source_file = self.config_dir / "source.json"
+        source_file = os.path.join(self.config_dir, "source.json")
 
-        if source_file.exists() and not self.use_local:
+        if os.path.exists(source_file) and not self.use_local:
             try:
-                source_config = SourceConfig.from_file(source_file)
+                source_config = SourceConfig.from_file(Path(source_file))
                 self.logger.debug(f"Using source config from: {source_config}")
                 return source_config
             except Exception as e:
                 self.logger.error(f"[red]Failed to load {source_file}: {e}[/red]")
                 sys.exit(1)
-        elif self.repo_path and self.repo_path.exists():
+        elif self.repo_path and os.path.exists(self.repo_path):
             self.logger.warning("Source configuration not found, will attempt to use locally stored plugin source code")
         else:
             self.logger.error(
@@ -256,35 +235,32 @@ class PluginFactoryConfig:
                 f"Either provide a valid {source_file} or ensure locally stored plugin source code exists at {self.repo_path}"
             )
             sys.exit(1)
+        return None
     
-    def setup_config_directory(self) -> "SourceConfig":
+    
+    def setup_config_directory(self) -> Optional["SourceConfig"]:
         """Setup and validate configuration directory structure."""
         self.logger.info("[bold blue]Setting up configuration directory[/bold blue]")
         
-        self.config_dir.mkdir(parents=True, exist_ok=True)
+        os.makedirs(self.config_dir, exist_ok=True)
         
-        env_file = self.config_dir / ".env"
-        if env_file.exists():
+        env_file = os.path.join(self.config_dir, ".env")
+        if os.path.exists(env_file):
             load_dotenv(env_file, override=True)
             self.logger.debug(f"Loaded .env file: {env_file}")
         
-        # Check for source configuration
         source_config = self.discover_source_config()
         if source_config:
-            self.logger.info(f"Found source configuration")
+            self.logger.info("Found source configuration")
             self.logger.info(f"  Repository: {source_config.repo}")
             self.logger.info(f"  Reference: {source_config.repo_ref}")
         
-        # Check for plugins-list.yaml
-        plugins_list_file = self.config_dir / "plugins-list.yaml"
+        plugins_list_file = os.path.join(self.config_dir, "plugins-list.yaml")
         
-        if plugins_list_file.exists():
+        if os.path.exists(plugins_list_file):
             self.logger.info(f"Using plugin list file: {plugins_list_file}")
-            plugins_yaml = yaml.dump(
-                yaml.safe_load(plugins_list_file.read_text()), 
-                indent=2
-            )
-            # Indent the multi-line yaml string once (two spaces) for better readability
+            with open(plugins_list_file, 'r') as f:
+                plugins_yaml = yaml.dump(yaml.safe_load(f), indent=2)
             indented_plugins_yaml = "\n".join("  " + line if line.strip() != "" else line for line in plugins_yaml.splitlines())
             self.logger.info(f"Plugins:\n{indented_plugins_yaml}")
         else:
@@ -300,22 +276,19 @@ class PluginFactoryConfig:
             self.logger.error(f"[red]Script not found: {script_path}[/red]")
             return False
         
-        workspace_path = self.repo_path.joinpath(self.workspace_path).absolute()
-        self.logger.debug(f"Applying patches and overlays to workspace: {workspace_path}")
-        # Run override-sources.sh script
+        workspace_full_path = os.path.abspath(os.path.join(self.repo_path, self.workspace_path))
+        self.logger.debug(f"Applying patches and overlays to workspace: {workspace_full_path}")
         cmd = [
-            str(script_path),
-            str(self.config_dir.absolute()),  # Overlay root directory
-            str(workspace_path),     # Target directory 
+            str(script_path.absolute()),
+            os.path.abspath(self.config_dir),  # Overlay root directory
+            workspace_full_path,     # Target directory 
         ]
 
         try:
-            # Stream output in real-time
-            # Use error logging for commands that patches and overlays
             returncode = run_command_with_streaming(
                 cmd,
                 self.logger,
-                cwd=workspace_path,
+                cwd=Path(workspace_full_path),
                 stderr_log_func=self.logger.error
             )
             
@@ -330,7 +303,7 @@ class PluginFactoryConfig:
             self.logger.error(f"[red]Failed to run patch script: {e}[/red]")
             return False
     
-    def export_plugins(self, output_dir: Path, push_images: bool) -> bool:
+    def export_plugins(self, output_dir: str, push_images: bool) -> bool:
         """Export plugins using export-workspace.sh script."""        
         script_dir = Path(__file__).parent.parent.parent / "scripts"
         script_path = script_dir / "export-workspace.sh"
@@ -339,46 +312,41 @@ class PluginFactoryConfig:
             self.logger.error(f"[red]Script not found: {script_path}[/red]")
             return False
         
-        plugins_list_file = self.config_dir / "plugins-list.yaml"
+        plugins_list_file = os.path.join(self.config_dir, "plugins-list.yaml")
         
-        if not plugins_list_file.exists():
+        if not os.path.exists(plugins_list_file):
             self.logger.error("[red]No plugins file found[/red]")
             return False    
 
-        # Load config directory .env file for script variables
-        config_env_file = self.config_dir / ".env"
+        config_env_file = os.path.join(self.config_dir, ".env")
         default_env_file = Path(__file__).parent.parent.parent / "default.env"
         load_dotenv(default_env_file)
         env = dict(os.environ)
         
-        if config_env_file.exists():
+        if os.path.exists(config_env_file):
             self.logger.debug(f"Loading script configuration from: {config_env_file}")
             load_dotenv(config_env_file, override=True)
             # Reload env after loading .env
             env = dict(os.environ)
         
-        output_dir.mkdir(parents=True, exist_ok=True)
-        env["INPUTS_DESTINATION"] = str(output_dir)
-        # Set required environment variables for the script
+        os.makedirs(output_dir, exist_ok=True)
+        env["INPUTS_DESTINATION"] = output_dir
         env.update({
             "INPUTS_SCALPRUM_CONFIG_FILE_NAME": "scalprum-config.json",
             "INPUTS_SOURCE_OVERLAY_FOLDER_NAME": "overlay",
             "INPUTS_SOURCE_PATCH_FILE_NAME": "patch",
             "INPUTS_APP_CONFIG_FILE_NAME": "app-config.dynamic.yaml",
-            "INPUTS_PLUGINS_FILE": str(plugins_list_file.absolute()),
+            "INPUTS_PLUGINS_FILE": os.path.abspath(plugins_list_file),
             "INPUTS_CLI_PACKAGE": "@red-hat-developer-hub/cli",
             "INPUTS_PUSH_CONTAINER_IMAGE": "true" if push_images else "false",
             "INPUTS_JANUS_CLI_VERSION": self.rhdh_cli_version,
             "INPUTS_IMAGE_REPOSITORY_PREFIX": f"{self.registry_url or 'localhost'}/{self.registry_namespace or 'default'}",
-            "INPUTS_DESTINATION": str(output_dir.absolute()),
+            "INPUTS_DESTINATION": os.path.abspath(output_dir),
             "INPUTS_CONTAINER_BUILD_TOOL": "buildah",
         })
         
-        # Run export-workspace.sh script in the workspace directory
-        workspace_path = self.repo_path.joinpath(self.workspace_path).absolute()
+        workspace_full_path = os.path.abspath(os.path.join(self.repo_path, self.workspace_path))
         try:
-            # Stream output in real-time
-            # Use error logging only for lines containing "Error", otherwise use info
             def conditional_stderr_log(line: str) -> None:
                 if "Error" in line:
                     self.logger.error(line)
@@ -390,7 +358,7 @@ class PluginFactoryConfig:
             returncode = run_command_with_streaming(
                 [str(script_path.absolute())],
                 self.logger,
-                cwd=workspace_path,
+                cwd=Path(workspace_full_path),
                 env=env,
                 stderr_log_func=conditional_stderr_log
             )
@@ -399,8 +367,7 @@ class PluginFactoryConfig:
                 self.logger.error(f"[red]Plugin export script failed with exit code {returncode}[/red]")
                 return False
             
-            # Check if any plugins failed to export
-            has_failures = display_export_results(workspace_path, self.logger)
+            has_failures = display_export_results(Path(workspace_full_path), self.logger)
             
             if has_failures:
                 self.logger.error("[red]Plugin export completed with failures[/red]")
@@ -425,7 +392,6 @@ class SourceConfig:
     @classmethod
     def from_file(cls, source_file: Path) -> "SourceConfig":
         """Load source configuration from JSON file."""
-        # Load and parse JSON file
         try:
             with open(source_file, 'r') as f:
                 data = json.load(f)
@@ -436,20 +402,17 @@ class SourceConfig:
         except Exception as e:
             raise ValueError(f"Failed to read {source_file}: {e}")
 
-        # Extract and validate required fields
         try:
             repo = data["repo"]
             repo_ref = data.get("repo-ref")
         except KeyError as e:
             raise ValueError(f"Missing required field {e} in {source_file}")
         
-        # Create config instance
         config = cls(
             repo=repo,
             repo_ref=repo_ref,
         )
 
-        # Validate all required fields are set
         if not config.repo:
             raise ValueError("repo is required")
         if not config.repo_ref:
@@ -483,7 +446,6 @@ class SourceConfig:
                 logger.error(f"Failed to clone repository (exit code {returncode})")
                 return False
             
-            # Checkout specific ref if provided
             if self.repo_ref:
                 cmd = ["git", "checkout", self.repo_ref]
                 logger.info(f"[cyan]Checking out ref: {self.repo_ref}[/cyan]")

--- a/src/rhdh_dynamic_plugin_factory/config.py
+++ b/src/rhdh_dynamic_plugin_factory/config.py
@@ -428,7 +428,7 @@ class SourceConfig:
             self.logger.error(f"[red]Destination directory does not exist: {repo_path}[/red]")
             return True
         
-        self.logger.info(f"[bold blue]Cloning repository[/bold blue]")
+        self.logger.info("[bold blue]Cloning repository[/bold blue]")
         self.logger.info(f"Repository: {self.repo}")
         self.logger.info(f"Reference: {self.repo_ref}")
         self.logger.info(f"Destination directory: {repo_path}")

--- a/src/rhdh_dynamic_plugin_factory/logger.py
+++ b/src/rhdh_dynamic_plugin_factory/logger.py
@@ -3,8 +3,6 @@ Logging utilities for RHDH Plugin Factory.
 """
 
 import logging
-import sys
-from typing import Optional
 from rich.console import Console
 from rich.logging import RichHandler
 from rich.traceback import install

--- a/src/rhdh_dynamic_plugin_factory/logger.py
+++ b/src/rhdh_dynamic_plugin_factory/logger.py
@@ -25,10 +25,8 @@ def setup_logging(
         Configured logger instance
     """
     
-    # Install rich traceback handler
     install(show_locals=True)
     
-    # Get root logger
     logger = logging.getLogger("rhdh_dynamic_plugin_factory")
     logger.setLevel(getattr(logging, level.upper() if level.upper() in LEVELS else "INFO"))
     console = Console(stderr=True)

--- a/src/rhdh_dynamic_plugin_factory/utils.py
+++ b/src/rhdh_dynamic_plugin_factory/utils.py
@@ -71,15 +71,12 @@ def run_command_with_streaming(
         args=(process.stderr, stderr_log_func)
     )
     
-    # Start both threads
     stdout_thread.start()
     stderr_thread.start()
     
-    # Wait for both threads to complete
     stdout_thread.join()
     stderr_thread.join()
     
-    # Wait for process to complete and get return code
     process.wait()
     
     return process.returncode

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,12 +22,12 @@ def mock_args(tmp_path):
     """Create mock argparse.Namespace with default valid arguments."""
     args = argparse.Namespace(
         workspace_path=".",
-        config_dir=tmp_path / "config",
-        repo_path=tmp_path / "workspace",
+        config_dir=str(tmp_path / "config"),
+        repo_path=str(tmp_path / "workspace"),
         log_level="INFO",
         use_local=False,
         push_images=False,
-        output_dir=tmp_path / "outputs",
+        output_dir=str(tmp_path / "outputs"),
         verbose=False
     )
     return args
@@ -52,7 +52,7 @@ def valid_default_env(monkeypatch):
 
 
 @pytest.fixture
-def valid_source_json(tmp_path):
+def valid_source_json(tmp_path: Path):
     """Create a valid source.json file."""
     source_data = {
         "repo": "https://github.com/awslabs/backstage-plugins-for-aws",
@@ -71,7 +71,7 @@ def valid_source_json(tmp_path):
 
 
 @pytest.fixture
-def valid_plugins_list_yaml(tmp_path):
+def valid_plugins_list_yaml(tmp_path: Path):
     """Create a valid plugins-list.yaml file."""
     plugins_content = """plugins/ecs/frontend:
 plugins/ecs/backend: --embed-package @aws/aws-core-plugin-for-backstage-common --embed-package @aws/aws-core-plugin-for-backstage-node
@@ -87,7 +87,7 @@ plugins/ecs/backend: --embed-package @aws/aws-core-plugin-for-backstage-common -
 
 
 @pytest.fixture
-def temp_workspace(tmp_path):
+def temp_workspace(tmp_path: Path):
     """Create a temporary workspace directory with realistic structure."""
     workspace = tmp_path / "workspace"
     workspace.mkdir(parents=True, exist_ok=True)
@@ -114,7 +114,7 @@ def temp_workspace(tmp_path):
 
 
 @pytest.fixture
-def setup_test_env(tmp_path, monkeypatch, valid_default_env):
+def setup_test_env(tmp_path: Path):
     """
     Set up a complete test environment with all required files and environment variables.
     
@@ -124,8 +124,8 @@ def setup_test_env(tmp_path, monkeypatch, valid_default_env):
     config_dir = tmp_path / "config"
     config_dir.mkdir(parents=True, exist_ok=True)
     
-    workspace_dir = tmp_path / "workspace"
-    workspace_dir.mkdir(parents=True, exist_ok=True)
+    source_dir = tmp_path / "source"
+    source_dir.mkdir(parents=True, exist_ok=True)
     
     # Create source.json
     source_data = {
@@ -142,16 +142,15 @@ plugins/ecs/backend: --embed-package @aws/aws-core-plugin-for-backstage-common
 """
     (config_dir / "plugins-list.yaml").write_text(plugins_content)
     
-    # Return paths
     return {
-        "config_dir": config_dir,
-        "workspace_dir": workspace_dir,
+        "config_dir": str(config_dir),
+        "source_dir": str(source_dir),
         "tmp_path": tmp_path
     }
 
 
 @pytest.fixture
-def clean_env(monkeypatch):
+def clean_env(monkeypatch: pytest.MonkeyPatch):
     """Clean environment fixture that removes all relevant environment variables."""
     # Remove all relevant environment variables
     env_vars = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ Tests the configuration loading, validation, and setup functionality
 without executing shell scripts.
 """
 
+import os
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 import pytest
@@ -20,7 +21,7 @@ class TestPluginFactoryConfigLoadFromEnv:
         """Test loading configuration with all required fields present."""
         # Update mock_args to use the setup_test_env paths
         mock_args.config_dir = setup_test_env["config_dir"]
-        mock_args.repo_path = setup_test_env["workspace_dir"]
+        mock_args.repo_path = setup_test_env["source_dir"]
         mock_args.workspace_path = "."
         
         # Ensure environment variables are set
@@ -34,18 +35,18 @@ class TestPluginFactoryConfigLoadFromEnv:
         assert config.rhdh_cli_version == "1.7.2"
         assert config.log_level == "INFO"
         assert config.config_dir == setup_test_env["config_dir"]
-        assert config.repo_path == setup_test_env["workspace_dir"]
-        assert config.workspace_path == Path(".")
+        assert config.repo_path == setup_test_env["source_dir"]
+        assert config.workspace_path == "."
         assert config.use_local is False
         
-        # Verify directories were created
-        assert config.config_dir.exists()
-        assert config.repo_path.exists()
+        # Verify directories exist
+        assert os.path.exists(config.config_dir)
+        assert os.path.exists(config.repo_path)
         
-        # Verify path types
-        assert isinstance(config.config_dir, Path)
-        assert isinstance(config.repo_path, Path)
-        assert isinstance(config.workspace_path, Path)
+        # Verify path types are strings
+        assert isinstance(config.config_dir, str)
+        assert isinstance(config.repo_path, str)
+        assert isinstance(config.workspace_path, str)
     
     def test_load_from_env_missing_rhdh_cli_version(self, mock_args, setup_test_env, clean_env):
         """Test that missing RHDH_CLI_VERSION raises ValueError."""
@@ -53,7 +54,7 @@ class TestPluginFactoryConfigLoadFromEnv:
         clean_env.setenv("WORKSPACE_PATH", ".")
         
         mock_args.config_dir = setup_test_env["config_dir"]
-        mock_args.repo_path = setup_test_env["workspace_dir"]
+        mock_args.repo_path = setup_test_env["source_dir"]
         mock_args.workspace_path = "."
         
         # Patch to prevent loading from default.env
@@ -69,7 +70,7 @@ class TestPluginFactoryConfigLoadFromEnv:
         monkeypatch.setenv("LOG_LEVEL", "INVALID_LEVEL")
         
         mock_args.config_dir = setup_test_env["config_dir"]
-        mock_args.repo_path = setup_test_env["workspace_dir"]
+        mock_args.repo_path = setup_test_env["source_dir"]
         mock_args.workspace_path = "."
         mock_args.log_level = "INVALID_LEVEL"
         
@@ -84,7 +85,7 @@ class TestPluginFactoryConfigLoadFromEnv:
         monkeypatch.setenv("LOG_LEVEL", log_level)
         
         mock_args.config_dir = setup_test_env["config_dir"]
-        mock_args.repo_path = setup_test_env["workspace_dir"]
+        mock_args.repo_path = setup_test_env["source_dir"]
         mock_args.workspace_path = "."
         mock_args.log_level = log_level
         
@@ -103,7 +104,7 @@ class TestPluginFactoryConfigLoadFromEnv:
         custom_env_file.write_text("RHDH_CLI_VERSION=1.5.0\n")
         
         mock_args.config_dir = setup_test_env["config_dir"]
-        mock_args.repo_path = setup_test_env["workspace_dir"]
+        mock_args.repo_path = setup_test_env["source_dir"]
         mock_args.workspace_path = "."
         
         # Load the config - the custom env file is loaded with override=True
@@ -127,7 +128,7 @@ class TestPluginFactoryConfigLoadFromEnv:
         monkeypatch.setenv("WORKSPACE_PATH", ".")
         
         mock_args.config_dir = setup_test_env["config_dir"]
-        mock_args.repo_path = setup_test_env["workspace_dir"]
+        mock_args.repo_path = setup_test_env["source_dir"]
         mock_args.workspace_path = "."
         
         # Load with custom env file (should be loaded and override defaults)
@@ -152,14 +153,18 @@ class TestPluginFactoryConfigLoadFromEnv:
         assert config.registry_namespace == "test-namespace"
     
     def test_load_from_env_missing_workspace_path(self, mock_args, setup_test_env, monkeypatch):
-        """Test that missing workspace_path handles gracefully with sys.exit."""
+        """Test that missing workspace_path raises ValueError."""
         monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
+        # Don't set WORKSPACE_PATH env var to test fallback
+        monkeypatch.delenv("WORKSPACE_PATH", raising=False)
         
         mock_args.config_dir = setup_test_env["config_dir"]
-        mock_args.repo_path = setup_test_env["workspace_dir"]
+        mock_args.repo_path = setup_test_env["source_dir"]
         mock_args.workspace_path = None  # Missing workspace_path
         
-        with pytest.raises(SystemExit):
+        # When workspace_path is None and WORKSPACE_PATH env var is not set,
+        # validation should raise ValueError
+        with pytest.raises(ValueError, match="WORKSPACE_PATH must be set"):
             PluginFactoryConfig.load_from_env(mock_args)
     
     def test_load_from_env_directory_creation(self, mock_args, tmp_path, monkeypatch):
@@ -178,15 +183,15 @@ class TestPluginFactoryConfigLoadFromEnv:
         # Create dummy file in repo_path to satisfy validation
         (new_repo_path / "dummy.txt").write_text("test")
         
-        mock_args.config_dir = new_config_dir
-        mock_args.repo_path = new_repo_path
+        mock_args.config_dir = str(new_config_dir)
+        mock_args.repo_path = str(new_repo_path)
         mock_args.workspace_path = "."
         
         config = PluginFactoryConfig.load_from_env(mock_args)
         
-        # Verify directories were created
-        assert config.config_dir.exists()
-        assert config.repo_path.exists()
+        # Verify directories exist
+        assert os.path.exists(config.config_dir)
+        assert os.path.exists(config.repo_path)
         assert new_config_dir.exists()
         assert new_repo_path.exists()
     
@@ -201,7 +206,7 @@ class TestPluginFactoryConfigLoadFromEnv:
         monkeypatch.setenv("REGISTRY_INSECURE", "true")
         
         mock_args.config_dir = setup_test_env["config_dir"]
-        mock_args.repo_path = setup_test_env["workspace_dir"]
+        mock_args.repo_path = setup_test_env["source_dir"]
         mock_args.workspace_path = "."
         
         config = PluginFactoryConfig.load_from_env(mock_args)
@@ -220,7 +225,7 @@ class TestPluginFactoryConfigLoadFromEnv:
         monkeypatch.setenv("REGISTRY_INSECURE", "false")
         
         mock_args.config_dir = setup_test_env["config_dir"]
-        mock_args.repo_path = setup_test_env["workspace_dir"]
+        mock_args.repo_path = setup_test_env["source_dir"]
         mock_args.workspace_path = "."
         
         config = PluginFactoryConfig.load_from_env(mock_args)
@@ -233,7 +238,7 @@ class TestPluginFactoryConfigLoadFromEnv:
         monkeypatch.setenv("WORKSPACE_PATH", ".")
         
         mock_args.config_dir = setup_test_env["config_dir"]
-        mock_args.repo_path = setup_test_env["workspace_dir"]
+        mock_args.repo_path = setup_test_env["source_dir"]
         mock_args.workspace_path = "."
         mock_args.use_local = True
         
@@ -254,8 +259,8 @@ class TestPluginFactoryConfigLoadFromEnv:
         repo_path.mkdir(parents=True, exist_ok=True)
         # repo_path is empty (no files)
         
-        mock_args.config_dir = config_dir
-        mock_args.repo_path = repo_path
+        mock_args.config_dir = str(config_dir)
+        mock_args.repo_path = str(repo_path)
         mock_args.workspace_path = "."
         
         with pytest.raises(ValueError, match="source.json not found"):
@@ -275,16 +280,16 @@ class TestPluginFactoryConfigLoadFromEnv:
         repo_path.mkdir(parents=True, exist_ok=True)
         (repo_path / "some_file.txt").write_text("content")
         
-        mock_args.config_dir = config_dir
-        mock_args.repo_path = repo_path
+        mock_args.config_dir = str(config_dir)
+        mock_args.repo_path = str(repo_path)
         mock_args.workspace_path = "."
         
         # Should not raise, just log warning
         config = PluginFactoryConfig.load_from_env(mock_args)
         
         assert config is not None
-        assert config.config_dir == config_dir
-        assert config.repo_path == repo_path
+        assert config.config_dir == str(config_dir)
+        assert config.repo_path == str(repo_path)
 
 
 class TestLoadRegistryConfig:
@@ -298,9 +303,9 @@ class TestLoadRegistryConfig:
         # Create a minimal config without registry settings
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         
         # Mock the logger to verify log messages
         with patch.object(config, 'logger') as mock_logger:
@@ -319,9 +324,9 @@ class TestLoadRegistryConfig:
         # Create config without registry_url but with namespace
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         config.registry_url = None
         config.registry_namespace = "test-namespace"
         
@@ -336,9 +341,9 @@ class TestLoadRegistryConfig:
         # Create config with registry_url but without namespace
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         config.registry_url = "quay.io"
         config.registry_namespace = None
         
@@ -353,9 +358,9 @@ class TestLoadRegistryConfig:
         # Create config with full registry configuration
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         config.registry_url = "quay.io"
         config.registry_namespace = "test-namespace"
         config.registry_username = "test-user"
@@ -398,9 +403,9 @@ class TestLoadRegistryConfig:
         # Create config with full registry configuration
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         config.registry_url = "quay.io"
         config.registry_namespace = "test-namespace"
         config.registry_username = "test-user"
@@ -435,9 +440,9 @@ class TestLoadRegistryConfig:
         # Create config without credentials
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         config.registry_url = "quay.io"
         config.registry_namespace = "test-namespace"
         config.registry_username = None
@@ -455,9 +460,9 @@ class TestLoadRegistryConfig:
         # Create config without username
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         config.registry_url = "quay.io"
         config.registry_namespace = "test-namespace"
         config.registry_username = None
@@ -475,9 +480,9 @@ class TestLoadRegistryConfig:
         # Create config without password
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         config.registry_url = "quay.io"
         config.registry_namespace = "test-namespace"
         config.registry_username = "test-user"
@@ -495,9 +500,9 @@ class TestLoadRegistryConfig:
         # Create config with insecure registry
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         config.registry_url = "localhost:5000"
         config.registry_namespace = "test-namespace"
         config.registry_username = "test-user"
@@ -531,9 +536,9 @@ class TestLoadRegistryConfig:
         # Create config with secure registry (default)
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         config.registry_url = "quay.io"
         config.registry_namespace = "test-namespace"
         config.registry_username = "test-user"
@@ -572,9 +577,9 @@ class TestApplyPatchesAndOverlays:
         # Create config
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         
         # Mock the script path to exist
         script_dir = Path(__file__).parent.parent / "scripts"
@@ -597,15 +602,16 @@ class TestApplyPatchesAndOverlays:
                 # Verify command structure
                 cmd = call_args[0][0]
                 assert len(cmd) == 3
-                assert cmd[0] == str(script_path)
-                assert cmd[1] == str(config.config_dir.absolute())
-                assert cmd[2] == str(config.repo_path.joinpath(config.workspace_path).absolute())
+                assert cmd[0] == str(script_path.absolute())
+                assert cmd[1] == os.path.abspath(config.config_dir)
+                expected_workspace = os.path.abspath(os.path.join(config.repo_path, config.workspace_path))
+                assert cmd[2] == expected_workspace
                 
                 # Verify logger was passed
                 assert call_args[0][1] == config.logger
                 
                 # Verify working directory
-                assert call_args[1]["cwd"] == config.repo_path.joinpath(config.workspace_path).absolute()
+                assert call_args[1]["cwd"] == Path(expected_workspace)
                 
                 # Verify stderr_log_func is set to logger.error
                 assert call_args[1]["stderr_log_func"] == config.logger.error
@@ -618,9 +624,9 @@ class TestApplyPatchesAndOverlays:
         # Create config
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         
         # Mock script path to not exist
         with patch.object(Path, "exists", return_value=False):
@@ -643,9 +649,9 @@ class TestApplyPatchesAndOverlays:
         # Create config
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         
         # Mock run_command_with_streaming to return failure
         with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
@@ -670,9 +676,9 @@ class TestApplyPatchesAndOverlays:
         # Create config
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         
         # Mock run_command_with_streaming to raise an exception
         with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
@@ -703,47 +709,49 @@ class TestExportPlugins:
         # Create config
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         config.registry_url = "quay.io"
         config.registry_namespace = "test-namespace"
         
-        output_dir = tmp_path / "output"
+        output_dir = str(tmp_path / "output")
         
         # Mock the script path and plugins list to exist
         with patch.object(Path, "exists", return_value=True):
-            with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
-                with patch("src.rhdh_dynamic_plugin_factory.config.display_export_results") as mock_display:
-                    with patch("src.rhdh_dynamic_plugin_factory.config.load_dotenv"):
-                        mock_run_cmd.return_value = 0
-                        mock_display.return_value = False  # No failures
-                        
-                        result = config.export_plugins(output_dir, push_images=False)
-                        
-                        # Verify result
-                        assert result is True
-                        
-                        # Verify run_command_with_streaming was called
-                        mock_run_cmd.assert_called_once()
-                        call_args = mock_run_cmd.call_args
-                        
-                        # Verify command structure
-                        cmd = call_args[0][0]
-                        assert len(cmd) == 1
-                        assert "export-workspace.sh" in cmd[0]
-                        
-                        # Verify logger was passed
-                        assert call_args[0][1] == config.logger
-                        
-                        # Verify working directory
-                        assert call_args[1]["cwd"] == config.repo_path.joinpath(config.workspace_path).absolute()
-                        
-                        # Verify env was passed
-                        env = call_args[1]["env"]
-                        assert "INPUTS_DESTINATION" in env
-                        assert "INPUTS_PLUGINS_FILE" in env
-                        assert "INPUTS_PUSH_CONTAINER_IMAGE" in env
+            with patch("os.path.exists", return_value=True):
+                with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
+                    with patch("src.rhdh_dynamic_plugin_factory.config.display_export_results") as mock_display:
+                        with patch("src.rhdh_dynamic_plugin_factory.config.load_dotenv"):
+                            mock_run_cmd.return_value = 0
+                            mock_display.return_value = False  # No failures
+                            
+                            result = config.export_plugins(output_dir, push_images=False)
+                            
+                            # Verify result
+                            assert result is True
+                            
+                            # Verify run_command_with_streaming was called
+                            mock_run_cmd.assert_called_once()
+                            call_args = mock_run_cmd.call_args
+                            
+                            # Verify command structure
+                            cmd = call_args[0][0]
+                            assert len(cmd) == 1
+                            assert "export-workspace.sh" in cmd[0]
+                            
+                            # Verify logger was passed
+                            assert call_args[0][1] == config.logger
+                            
+                            # Verify working directory
+                            expected_workspace = os.path.abspath(os.path.join(config.repo_path, config.workspace_path))
+                            assert call_args[1]["cwd"] == Path(expected_workspace)
+                            
+                            # Verify env was passed
+                            env = call_args[1]["env"]
+                            assert "INPUTS_DESTINATION" in env
+                            assert "INPUTS_PLUGINS_FILE" in env
+                            assert "INPUTS_PUSH_CONTAINER_IMAGE" in env
     
     def test_export_plugins_environment_variables_no_push(self, setup_test_env, monkeypatch, tmp_path):
         """Test that environment variables are correctly set when push_images is False."""
@@ -753,39 +761,40 @@ class TestExportPlugins:
         # Create config
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         config.registry_url = "quay.io"
         config.registry_namespace = "test-namespace"
         
-        output_dir = tmp_path / "output"
+        output_dir = str(tmp_path / "output")
         
         # Mock the script path and plugins list to exist
         with patch.object(Path, "exists", return_value=True):
-            with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
-                with patch("src.rhdh_dynamic_plugin_factory.config.display_export_results") as mock_display:
-                    with patch("src.rhdh_dynamic_plugin_factory.config.load_dotenv"):
-                        mock_run_cmd.return_value = 0
-                        mock_display.return_value = False
-                        
-                        result = config.export_plugins(output_dir, push_images=False)
-                        
-                        # Get the env dict that was passed
-                        env = mock_run_cmd.call_args[1]["env"]
-                        
-                        # Verify required environment variables
-                        assert env["INPUTS_SCALPRUM_CONFIG_FILE_NAME"] == "scalprum-config.json"
-                        assert env["INPUTS_SOURCE_OVERLAY_FOLDER_NAME"] == "overlay"
-                        assert env["INPUTS_SOURCE_PATCH_FILE_NAME"] == "patch"
-                        assert env["INPUTS_APP_CONFIG_FILE_NAME"] == "app-config.dynamic.yaml"
-                        assert env["INPUTS_CLI_PACKAGE"] == "@red-hat-developer-hub/cli"
-                        assert env["INPUTS_PUSH_CONTAINER_IMAGE"] == "false"
-                        assert env["INPUTS_JANUS_CLI_VERSION"] == "1.7.2"
-                        assert env["INPUTS_IMAGE_REPOSITORY_PREFIX"] == "quay.io/test-namespace"
-                        assert env["INPUTS_CONTAINER_BUILD_TOOL"] == "buildah"
-                        assert str(output_dir.absolute()) in env["INPUTS_DESTINATION"]
-                        assert "plugins-list.yaml" in env["INPUTS_PLUGINS_FILE"]
+            with patch("os.path.exists", return_value=True):
+                with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
+                    with patch("src.rhdh_dynamic_plugin_factory.config.display_export_results") as mock_display:
+                        with patch("src.rhdh_dynamic_plugin_factory.config.load_dotenv"):
+                            mock_run_cmd.return_value = 0
+                            mock_display.return_value = False
+                            
+                            _result = config.export_plugins(output_dir, push_images=False)
+                            
+                            # Get the env dict that was passed
+                            env = mock_run_cmd.call_args[1]["env"]
+                            
+                            # Verify required environment variables
+                            assert env["INPUTS_SCALPRUM_CONFIG_FILE_NAME"] == "scalprum-config.json"
+                            assert env["INPUTS_SOURCE_OVERLAY_FOLDER_NAME"] == "overlay"
+                            assert env["INPUTS_SOURCE_PATCH_FILE_NAME"] == "patch"
+                            assert env["INPUTS_APP_CONFIG_FILE_NAME"] == "app-config.dynamic.yaml"
+                            assert env["INPUTS_CLI_PACKAGE"] == "@red-hat-developer-hub/cli"
+                            assert env["INPUTS_PUSH_CONTAINER_IMAGE"] == "false"
+                            assert env["INPUTS_JANUS_CLI_VERSION"] == "1.7.2"
+                            assert env["INPUTS_IMAGE_REPOSITORY_PREFIX"] == "quay.io/test-namespace"
+                            assert env["INPUTS_CONTAINER_BUILD_TOOL"] == "buildah"
+                            assert str((tmp_path / "output").absolute()) in env["INPUTS_DESTINATION"]
+                            assert "plugins-list.yaml" in env["INPUTS_PLUGINS_FILE"]
     
     def test_export_plugins_environment_variables_with_push(self, setup_test_env, monkeypatch, tmp_path):
         """Test that environment variables are correctly set when push_images is True."""
@@ -795,29 +804,30 @@ class TestExportPlugins:
         # Create config
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         config.registry_url = "quay.io"
         config.registry_namespace = "test-namespace"
         
-        output_dir = tmp_path / "output"
+        output_dir = str(tmp_path / "output")
         
         # Mock the script path and plugins list to exist
         with patch.object(Path, "exists", return_value=True):
-            with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
-                with patch("src.rhdh_dynamic_plugin_factory.config.display_export_results") as mock_display:
-                    with patch("src.rhdh_dynamic_plugin_factory.config.load_dotenv"):
-                        mock_run_cmd.return_value = 0
-                        mock_display.return_value = False
-                        
-                        result = config.export_plugins(output_dir, push_images=True)
-                        
-                        # Get the env dict that was passed
-                        env = mock_run_cmd.call_args[1]["env"]
-                        
-                        # Verify INPUTS_PUSH_CONTAINER_IMAGE is set to "true"
-                        assert env["INPUTS_PUSH_CONTAINER_IMAGE"] == "true"
+            with patch("os.path.exists", return_value=True):
+                with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
+                    with patch("src.rhdh_dynamic_plugin_factory.config.display_export_results") as mock_display:
+                        with patch("src.rhdh_dynamic_plugin_factory.config.load_dotenv"):
+                            mock_run_cmd.return_value = 0
+                            mock_display.return_value = False
+                            
+                            _result = config.export_plugins(output_dir, push_images=True)
+                            
+                            # Get the env dict that was passed
+                            env = mock_run_cmd.call_args[1]["env"]
+                            
+                            # Verify INPUTS_PUSH_CONTAINER_IMAGE is set to "true"
+                            assert env["INPUTS_PUSH_CONTAINER_IMAGE"] == "true"
     
     def test_export_plugins_default_registry_values(self, setup_test_env, monkeypatch, tmp_path):
         """Test that default values are used when registry_url or registry_namespace are None."""
@@ -827,29 +837,30 @@ class TestExportPlugins:
         # Create config without registry settings
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         config.registry_url = None
         config.registry_namespace = None
         
-        output_dir = tmp_path / "output"
+        output_dir = str(tmp_path / "output")
         
         # Mock the script path and plugins list to exist
         with patch.object(Path, "exists", return_value=True):
-            with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
-                with patch("src.rhdh_dynamic_plugin_factory.config.display_export_results") as mock_display:
-                    with patch("src.rhdh_dynamic_plugin_factory.config.load_dotenv"):
-                        mock_run_cmd.return_value = 0
-                        mock_display.return_value = False
-                        
-                        _result = config.export_plugins(output_dir, push_images=False)
-                        
-                        # Get the env dict that was passed
-                        env = mock_run_cmd.call_args[1]["env"]
-                        
-                        # Verify default values are used
-                        assert env["INPUTS_IMAGE_REPOSITORY_PREFIX"] == "localhost/default"
+            with patch("os.path.exists", return_value=True):
+                with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
+                    with patch("src.rhdh_dynamic_plugin_factory.config.display_export_results") as mock_display:
+                        with patch("src.rhdh_dynamic_plugin_factory.config.load_dotenv"):
+                            mock_run_cmd.return_value = 0
+                            mock_display.return_value = False
+                            
+                            _result = config.export_plugins(output_dir, push_images=False)
+                            
+                            # Get the env dict that was passed
+                            env = mock_run_cmd.call_args[1]["env"]
+                            
+                            # Verify default values are used
+                            assert env["INPUTS_IMAGE_REPOSITORY_PREFIX"] == "localhost/default"
     
     def test_export_plugins_script_not_found(self, setup_test_env, monkeypatch, tmp_path):
         """Test that export_plugins returns False when script doesn't exist."""
@@ -859,11 +870,11 @@ class TestExportPlugins:
         # Create config
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         
-        output_dir = tmp_path / "output"
+        output_dir = str(tmp_path / "output")
         
         # Mock script path to not exist
         with patch.object(Path, "exists", return_value=False):
@@ -886,32 +897,36 @@ class TestExportPlugins:
         # Create config
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         
-        output_dir = tmp_path / "output"
+        output_dir = str(tmp_path / "output")
         
         # Mock: script exists but plugins-list.yaml doesn't
-        original_exists = Path.exists
+        original_path_exists = Path.exists
         
-        def exists_side_effect(path_obj):
+        def path_exists_side_effect(path_obj):
             if "export-workspace.sh" in str(path_obj):
                 return True
-            elif "plugins-list.yaml" in str(path_obj):
-                return False
-            return original_exists(path_obj)
+            return original_path_exists(path_obj)
         
-        with patch.object(Path, "exists", new=exists_side_effect):
-            with patch.object(config, "logger") as mock_logger:
-                result = config.export_plugins(output_dir, push_images=False)
-                
-                # Verify result
-                assert result is False
-                
-                # Verify error was logged
-                error_calls = [call[0][0] for call in mock_logger.error.call_args_list]
-                assert any("No plugins file found" in str(call) for call in error_calls)
+        def os_exists_side_effect(path_str):
+            if "plugins-list.yaml" in str(path_str):
+                return False
+            return True
+        
+        with patch.object(Path, "exists", new=path_exists_side_effect):
+            with patch("os.path.exists", side_effect=os_exists_side_effect):
+                with patch.object(config, "logger") as mock_logger:
+                    result = config.export_plugins(output_dir, push_images=False)
+                    
+                    # Verify result
+                    assert result is False
+                    
+                    # Verify error was logged
+                    error_calls = [call[0][0] for call in mock_logger.error.call_args_list]
+                    assert any("No plugins file found" in str(call) for call in error_calls)
     
     def test_export_plugins_script_fails(self, setup_test_env, monkeypatch, tmp_path):
         """Test that export_plugins returns False when script returns non-zero exit code."""
@@ -921,29 +936,30 @@ class TestExportPlugins:
         # Create config
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         config.registry_url = "quay.io"
         config.registry_namespace = "test-namespace"
         
-        output_dir = tmp_path / "output"
+        output_dir = str(tmp_path / "output")
         
         # Mock run_command_with_streaming to return failure
         with patch.object(Path, "exists", return_value=True):
-            with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
-                with patch("src.rhdh_dynamic_plugin_factory.config.load_dotenv"):
-                    with patch.object(config, "logger") as mock_logger:
-                        mock_run_cmd.return_value = 1
-                        
-                        result = config.export_plugins(output_dir, push_images=False)
-                        
-                        # Verify result
-                        assert result is False
-                        
-                        # Verify error was logged with exit code
-                        error_calls = [call[0][0] for call in mock_logger.error.call_args_list]
-                        assert any("exit code 1" in str(call) for call in error_calls)
+            with patch("os.path.exists", return_value=True):
+                with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
+                    with patch("src.rhdh_dynamic_plugin_factory.config.load_dotenv"):
+                        with patch.object(config, "logger") as mock_logger:
+                            mock_run_cmd.return_value = 1
+                            
+                            result = config.export_plugins(output_dir, push_images=False)
+                            
+                            # Verify result
+                            assert result is False
+                            
+                            # Verify error was logged with exit code
+                            error_calls = [call[0][0] for call in mock_logger.error.call_args_list]
+                            assert any("exit code 1" in str(call) for call in error_calls)
     
     def test_export_plugins_has_failures(self, setup_test_env, monkeypatch, tmp_path):
         """Test that export_plugins returns False when display_export_results indicates failures."""
@@ -953,31 +969,32 @@ class TestExportPlugins:
         # Create config
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         config.registry_url = "quay.io"
         config.registry_namespace = "test-namespace"
         
-        output_dir = tmp_path / "output"
+        output_dir = str(tmp_path / "output")
         
         # Mock: script succeeds but display_export_results indicates failures
         with patch.object(Path, "exists", return_value=True):
-            with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
-                with patch("src.rhdh_dynamic_plugin_factory.config.display_export_results") as mock_display:
-                    with patch("src.rhdh_dynamic_plugin_factory.config.load_dotenv"):
-                        with patch.object(config, "logger") as mock_logger:
-                            mock_run_cmd.return_value = 0
-                            mock_display.return_value = True  # Has failures
-                            
-                            result = config.export_plugins(output_dir, push_images=False)
-                            
-                            # Verify result
-                            assert result is False
-                            
-                            # Verify error was logged
-                            error_calls = [call[0][0] for call in mock_logger.error.call_args_list]
-                            assert any("completed with failures" in str(call) for call in error_calls)
+            with patch("os.path.exists", return_value=True):
+                with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
+                    with patch("src.rhdh_dynamic_plugin_factory.config.display_export_results") as mock_display:
+                        with patch("src.rhdh_dynamic_plugin_factory.config.load_dotenv"):
+                            with patch.object(config, "logger") as mock_logger:
+                                mock_run_cmd.return_value = 0
+                                mock_display.return_value = True  # Has failures
+                                
+                                result = config.export_plugins(output_dir, push_images=False)
+                                
+                                # Verify result
+                                assert result is False
+                                
+                                # Verify error was logged
+                                error_calls = [call[0][0] for call in mock_logger.error.call_args_list]
+                                assert any("completed with failures" in str(call) for call in error_calls)
     
     def test_export_plugins_exception(self, setup_test_env, monkeypatch, tmp_path):
         """Test that export_plugins handles exceptions gracefully."""
@@ -987,29 +1004,30 @@ class TestExportPlugins:
         # Create config
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         
-        output_dir = tmp_path / "output"
+        output_dir = str(tmp_path / "output")
         
         # Mock run_command_with_streaming to raise an exception
         with patch.object(Path, "exists", return_value=True):
-            with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
-                with patch("src.rhdh_dynamic_plugin_factory.config.load_dotenv"):
-                    with patch.object(config, "logger") as mock_logger:
-                        mock_run_cmd.side_effect = Exception("Test exception")
-                        
-                        result = config.export_plugins(output_dir, push_images=False)
-                        
-                        # Verify result
-                        assert result is False
-                        
-                        # Verify error was logged
-                        mock_logger.error.assert_called()
-                        error_msg = mock_logger.error.call_args[0][0]
-                        assert "Failed to run export script" in error_msg
-                        assert "Test exception" in error_msg
+            with patch("os.path.exists", return_value=True):
+                with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
+                    with patch("src.rhdh_dynamic_plugin_factory.config.load_dotenv"):
+                        with patch.object(config, "logger") as mock_logger:
+                            mock_run_cmd.side_effect = Exception("Test exception")
+                            
+                            result = config.export_plugins(output_dir, push_images=False)
+                            
+                            # Verify result
+                            assert result is False
+                            
+                            # Verify error was logged
+                            mock_logger.error.assert_called()
+                            error_msg = mock_logger.error.call_args[0][0]
+                            assert "Failed to run export script" in error_msg
+                            assert "Test exception" in error_msg
     
     def test_export_plugins_custom_env_file(self, setup_test_env, monkeypatch, tmp_path):
         """Test that export_plugins loads custom .env file from config directory."""
@@ -1019,33 +1037,34 @@ class TestExportPlugins:
         # Create config
         config = PluginFactoryConfig()
         config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["workspace_dir"]
+        config.repo_path = setup_test_env["source_dir"]
         config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = Path(".")
+        config.workspace_path = "."
         config.registry_url = "quay.io"
         config.registry_namespace = "test-namespace"
         
         # Create a custom .env file in config directory
-        custom_env = setup_test_env["config_dir"] / ".env"
+        custom_env = Path(setup_test_env["config_dir"]) / ".env"
         custom_env.write_text("CUSTOM_VAR=custom_value\n")
         
-        output_dir = tmp_path / "output"
+        output_dir = str(tmp_path / "output")
         
         # Track load_dotenv calls
         with patch.object(Path, "exists", return_value=True):
-            with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
-                with patch("src.rhdh_dynamic_plugin_factory.config.display_export_results") as mock_display:
-                    with patch("src.rhdh_dynamic_plugin_factory.config.load_dotenv") as mock_load_dotenv:
-                        with patch.object(config, "logger") as mock_logger:
-                            mock_run_cmd.return_value = 0
-                            mock_display.return_value = False
-                            
-                            _result = config.export_plugins(output_dir, push_images=False)
-                            
-                            # Verify load_dotenv was called
-                            assert mock_load_dotenv.call_count >= 1
-                            
-                            # Verify debug log about loading custom env
-                            debug_calls = [call[0][0] for call in mock_logger.debug.call_args_list]
-                            assert any(".env" in str(call) for call in debug_calls)
+            with patch("os.path.exists", return_value=True):
+                with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
+                    with patch("src.rhdh_dynamic_plugin_factory.config.display_export_results") as mock_display:
+                        with patch("src.rhdh_dynamic_plugin_factory.config.load_dotenv") as mock_load_dotenv:
+                            with patch.object(config, "logger") as mock_logger:
+                                mock_run_cmd.return_value = 0
+                                mock_display.return_value = False
+                                
+                                _result = config.export_plugins(output_dir, push_images=False)
+                                
+                                # Verify load_dotenv was called
+                                assert mock_load_dotenv.call_count >= 1
+                                
+                                # Verify debug log about loading custom env
+                                debug_calls = [call[0][0] for call in mock_logger.debug.call_args_list]
+                                assert any(".env" in str(call) for call in debug_calls)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -295,87 +295,46 @@ class TestPluginFactoryConfigLoadFromEnv:
 class TestLoadRegistryConfig:
     """Tests for PluginFactoryConfig.load_registry_config method."""
     
-    def test_skip_when_push_images_false(self, setup_test_env, monkeypatch):
+    def test_skip_when_push_images_false(self, make_config):
         """Test that registry configuration is skipped when push_images is False."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
+        config = make_config()
         
-        # Create a minimal config without registry settings
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        
-        # Mock the logger to verify log messages
         with patch.object(config, 'logger') as mock_logger:
             config.load_registry_config(push_images=False)
-            
-            # Verify info log was called with skip message
             mock_logger.info.assert_called_once_with(
                 "Skipping registry configuration (not pushing images)"
             )
     
-    def test_missing_registry_url(self, setup_test_env, monkeypatch):
+    def test_missing_registry_url(self, make_config):
         """Test that missing REGISTRY_URL raises ValueError when push_images is True."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
-        
-        # Create config without registry_url but with namespace
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        config.registry_url = None
-        config.registry_namespace = "test-namespace"
+        config = make_config(registry_url=None, registry_namespace="test-namespace")
         
         with pytest.raises(ValueError, match="REGISTRY_URL environment variable is required"):
             config.load_registry_config(push_images=True)
     
-    def test_missing_registry_namespace(self, setup_test_env, monkeypatch):
+    def test_missing_registry_namespace(self, make_config):
         """Test that missing REGISTRY_NAMESPACE raises ValueError when push_images is True."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
-        
-        # Create config with registry_url but without namespace
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        config.registry_url = "quay.io"
-        config.registry_namespace = None
+        config = make_config(registry_url="quay.io", registry_namespace=None)
         
         with pytest.raises(ValueError, match="REGISTRY_NAMESPACE environment variable is required"):
             config.load_registry_config(push_images=True)
     
-    def test_successful_buildah_login(self, setup_test_env, monkeypatch):
+    def test_successful_buildah_login(self, make_config):
         """Test successful buildah login with valid credentials."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
+        config = make_config(
+            registry_url="quay.io",
+            registry_namespace="test-namespace",
+            registry_username="test-user",
+            registry_password="test-password",
+            registry_insecure=False
+        )
         
-        # Create config with full registry configuration
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        config.registry_url = "quay.io"
-        config.registry_namespace = "test-namespace"
-        config.registry_username = "test-user"
-        config.registry_password = "test-password"
-        config.registry_insecure = False
-        
-        # Mock subprocess.run to simulate successful login
         with patch('subprocess.run') as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
             
-            # Mock the logger to verify log messages
             with patch.object(config, 'logger') as mock_logger:
                 config.load_registry_config(push_images=True)
                 
-                # Verify buildah command was called correctly
                 mock_run.assert_called_once()
                 call_args = mock_run.call_args
                 
@@ -390,29 +349,20 @@ class TestLoadRegistryConfig:
                 assert call_args[1]['stdout'] == subprocess.PIPE
                 assert call_args[1]['stderr'] == subprocess.PIPE
                 
-                # Verify success log message
                 mock_logger.info.assert_called_with(
                     "Logged in to registry quay.io with buildah."
                 )
     
-    def test_failed_buildah_login(self, setup_test_env, monkeypatch):
+    def test_failed_buildah_login(self, make_config):
         """Test that failed buildah login logs warning but doesn't raise."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
+        config = make_config(
+            registry_url="quay.io",
+            registry_namespace="test-namespace",
+            registry_username="test-user",
+            registry_password="wrong-password",
+            registry_insecure=False
+        )
         
-        # Create config with full registry configuration
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        config.registry_url = "quay.io"
-        config.registry_namespace = "test-namespace"
-        config.registry_username = "test-user"
-        config.registry_password = "wrong-password"
-        config.registry_insecure = False
-        
-        # Mock subprocess.run to simulate failed login
         with patch('subprocess.run') as mock_run:
             mock_error = subprocess.CalledProcessError(
                 returncode=1,
@@ -421,101 +371,68 @@ class TestLoadRegistryConfig:
             )
             mock_run.side_effect = mock_error
             
-            # Mock the logger to verify warning message
             with patch.object(config, 'logger') as mock_logger:
-                # Should not raise, just log warning
                 config.load_registry_config(push_images=True)
                 
-                # Verify warning log message
                 mock_logger.warning.assert_called_once()
                 warning_call = mock_logger.warning.call_args[0][0]
                 assert "Failed to login to registry quay.io" in warning_call
                 assert "Authentication failed" in warning_call
     
-    def test_missing_registry_credentials(self, setup_test_env, monkeypatch):
+    def test_missing_registry_credentials(self, make_config):
         """Test that missing credentials raise ValueError when push_images is True."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
-        
-        # Create config without credentials
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        config.registry_url = "quay.io"
-        config.registry_namespace = "test-namespace"
-        config.registry_username = None
-        config.registry_password = None
-        config.registry_insecure = False
+        config = make_config(
+            registry_url="quay.io",
+            registry_namespace="test-namespace",
+            registry_username=None,
+            registry_password=None,
+            registry_insecure=False
+        )
         
         with pytest.raises(ValueError, match="REGISTRY_USERNAME and REGISTRY_PASSWORD environment variables are required"):
             config.load_registry_config(push_images=True)
     
-    def test_missing_registry_username(self, setup_test_env, monkeypatch):
+    def test_missing_registry_username(self, make_config):
         """Test that missing username raises ValueError when push_images is True."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
-        
-        # Create config without username
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        config.registry_url = "quay.io"
-        config.registry_namespace = "test-namespace"
-        config.registry_username = None
-        config.registry_password = "test-password"
-        config.registry_insecure = False
+        config = make_config(
+            registry_url="quay.io",
+            registry_namespace="test-namespace",
+            registry_username=None,
+            registry_password="test-password",
+            registry_insecure=False
+        )
         
         with pytest.raises(ValueError, match="REGISTRY_USERNAME and REGISTRY_PASSWORD environment variables are required"):
             config.load_registry_config(push_images=True)
     
-    def test_missing_registry_password(self, setup_test_env, monkeypatch):
+    def test_missing_registry_password(self, make_config):
         """Test that missing password raises ValueError when push_images is True."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
-        
-        # Create config without password
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        config.registry_url = "quay.io"
-        config.registry_namespace = "test-namespace"
-        config.registry_username = "test-user"
-        config.registry_password = None
-        config.registry_insecure = False
+        config = make_config(
+            registry_url="quay.io",
+            registry_namespace="test-namespace",
+            registry_username="test-user",
+            registry_password=None,
+            registry_insecure=False
+        )
         
         with pytest.raises(ValueError, match="REGISTRY_USERNAME and REGISTRY_PASSWORD environment variables are required"):
             config.load_registry_config(push_images=True)
     
-    def test_insecure_registry_flag(self, setup_test_env, monkeypatch):
+    def test_insecure_registry_flag(self, make_config):
         """Test that insecure flag is added to buildah command when registry_insecure is True."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
+        config = make_config(
+            registry_url="localhost:5000",
+            registry_namespace="test-namespace",
+            registry_username="test-user",
+            registry_password="test-password",
+            registry_insecure=True
+        )
         
-        # Create config with insecure registry
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        config.registry_url = "localhost:5000"
-        config.registry_namespace = "test-namespace"
-        config.registry_username = "test-user"
-        config.registry_password = "test-password"
-        config.registry_insecure = True
-        
-        # Mock subprocess.run to capture the command
         with patch('subprocess.run') as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
             
             config.load_registry_config(push_images=True)
             
-            # Verify buildah command includes --tls-verify=false
             mock_run.assert_called_once()
             call_args = mock_run.call_args
             
@@ -528,30 +445,21 @@ class TestLoadRegistryConfig:
             ]
             assert call_args[0][0] == expected_cmd
     
-    def test_secure_registry_default(self, setup_test_env, monkeypatch):
+    def test_secure_registry_default(self, make_config):
         """Test that insecure flag is NOT added when registry_insecure is False."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
+        config = make_config(
+            registry_url="quay.io",
+            registry_namespace="test-namespace",
+            registry_username="test-user",
+            registry_password="test-password",
+            registry_insecure=False
+        )
         
-        # Create config with secure registry (default)
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        config.registry_url = "quay.io"
-        config.registry_namespace = "test-namespace"
-        config.registry_username = "test-user"
-        config.registry_password = "test-password"
-        config.registry_insecure = False
-        
-        # Mock subprocess.run to capture the command
         with patch('subprocess.run') as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
             
             config.load_registry_config(push_images=True)
             
-            # Verify buildah command does NOT include --tls-verify=false
             mock_run.assert_called_once()
             call_args = mock_run.call_args
             
@@ -562,44 +470,30 @@ class TestLoadRegistryConfig:
                 "quay.io"
             ]
             assert call_args[0][0] == expected_cmd
-            # Verify --tls-verify=false is NOT in the command
             assert "--tls-verify=false" not in call_args[0][0]
 
 
 class TestApplyPatchesAndOverlays:
     """Tests for PluginFactoryConfig.apply_patches_and_overlays method."""
     
-    def test_apply_patches_and_overlays_success(self, setup_test_env, monkeypatch):
+    def test_apply_patches_and_overlays_success(self, make_config):
         """Test successful execution of apply_patches_and_overlays."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
+        config = make_config()
         
-        # Create config
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        
-        # Mock the script path to exist
         script_dir = Path(__file__).parent.parent / "scripts"
         script_path = script_dir / "override-sources.sh"
         
-        # Mock run_command_with_streaming to return success
         with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
             with patch.object(Path, "exists", return_value=True):
                 mock_run_cmd.return_value = 0
                 
                 result = config.apply_patches_and_overlays()
                 
-                # Verify result
                 assert result is True
                 
-                # Verify run_command_with_streaming was called with correct arguments
                 mock_run_cmd.assert_called_once()
                 call_args = mock_run_cmd.call_args
                 
-                # Verify command structure
                 cmd = call_args[0][0]
                 assert len(cmd) == 3
                 assert cmd[0] == str(script_path.absolute())
@@ -607,53 +501,28 @@ class TestApplyPatchesAndOverlays:
                 expected_workspace = os.path.abspath(os.path.join(config.repo_path, config.workspace_path))
                 assert cmd[2] == expected_workspace
                 
-                # Verify logger was passed
                 assert call_args[0][1] == config.logger
-                
-                # Verify working directory
                 assert call_args[1]["cwd"] == Path(expected_workspace)
-                
-                # Verify stderr_log_func is set to logger.error
                 assert call_args[1]["stderr_log_func"] == config.logger.error
     
-    def test_apply_patches_and_overlays_script_not_found(self, setup_test_env, monkeypatch):
+    def test_apply_patches_and_overlays_script_not_found(self, make_config):
         """Test that apply_patches_and_overlays returns False when script doesn't exist."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
+        config = make_config()
         
-        # Create config
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        
-        # Mock script path to not exist
         with patch.object(Path, "exists", return_value=False):
             with patch.object(config, "logger") as mock_logger:
                 result = config.apply_patches_and_overlays()
                 
-                # Verify result
                 assert result is False
                 
-                # Verify error was logged
                 mock_logger.error.assert_called_once()
                 error_msg = mock_logger.error.call_args[0][0]
                 assert "Script not found" in error_msg
     
-    def test_apply_patches_and_overlays_script_fails(self, setup_test_env, monkeypatch):
+    def test_apply_patches_and_overlays_script_fails(self, make_config):
         """Test that apply_patches_and_overlays returns False when script returns non-zero exit code."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
+        config = make_config()
         
-        # Create config
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        
-        # Mock run_command_with_streaming to return failure
         with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
             with patch.object(Path, "exists", return_value=True):
                 with patch.object(config, "logger") as mock_logger:
@@ -661,26 +530,15 @@ class TestApplyPatchesAndOverlays:
                     
                     result = config.apply_patches_and_overlays()
                     
-                    # Verify result
                     assert result is False
                     
-                    # Verify error was logged with exit code
                     error_calls = [call[0][0] for call in mock_logger.error.call_args_list]
                     assert any("exit code 1" in str(call) for call in error_calls)
     
-    def test_apply_patches_and_overlays_exception(self, setup_test_env, monkeypatch):
+    def test_apply_patches_and_overlays_exception(self, make_config):
         """Test that apply_patches_and_overlays handles exceptions gracefully."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
+        config = make_config()
         
-        # Create config
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        
-        # Mock run_command_with_streaming to raise an exception
         with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
             with patch.object(Path, "exists", return_value=True):
                 with patch.object(config, "logger") as mock_logger:
@@ -688,10 +546,8 @@ class TestApplyPatchesAndOverlays:
                     
                     result = config.apply_patches_and_overlays()
                     
-                    # Verify result
                     assert result is False
                     
-                    # Verify error was logged
                     mock_logger.error.assert_called()
                     error_msg = mock_logger.error.call_args[0][0]
                     assert "Failed to run patch script" in error_msg
@@ -701,75 +557,54 @@ class TestApplyPatchesAndOverlays:
 class TestExportPlugins:
     """Tests for PluginFactoryConfig.export_plugins method."""
     
-    def test_export_plugins_success(self, setup_test_env, monkeypatch, tmp_path):
+    def test_export_plugins_success(self, make_config, setup_test_env):
         """Test successful execution of export_plugins."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
+        config = make_config(
+            registry_url="quay.io",
+            registry_namespace="test-namespace"
+        )
         
-        # Create config
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        config.registry_url = "quay.io"
-        config.registry_namespace = "test-namespace"
+        output_dir = str(setup_test_env["tmp_path"] / "output")
         
-        output_dir = str(tmp_path / "output")
-        
-        # Mock the script path and plugins list to exist
         with patch.object(Path, "exists", return_value=True):
             with patch("os.path.exists", return_value=True):
                 with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
                     with patch("src.rhdh_dynamic_plugin_factory.config.display_export_results") as mock_display:
                         with patch("src.rhdh_dynamic_plugin_factory.config.load_dotenv"):
                             mock_run_cmd.return_value = 0
-                            mock_display.return_value = False  # No failures
+                            mock_display.return_value = False
                             
                             result = config.export_plugins(output_dir, push_images=False)
                             
-                            # Verify result
                             assert result is True
                             
-                            # Verify run_command_with_streaming was called
                             mock_run_cmd.assert_called_once()
                             call_args = mock_run_cmd.call_args
                             
-                            # Verify command structure
                             cmd = call_args[0][0]
                             assert len(cmd) == 1
                             assert "export-workspace.sh" in cmd[0]
                             
-                            # Verify logger was passed
                             assert call_args[0][1] == config.logger
                             
-                            # Verify working directory
                             expected_workspace = os.path.abspath(os.path.join(config.repo_path, config.workspace_path))
                             assert call_args[1]["cwd"] == Path(expected_workspace)
                             
-                            # Verify env was passed
                             env = call_args[1]["env"]
                             assert "INPUTS_DESTINATION" in env
                             assert "INPUTS_PLUGINS_FILE" in env
                             assert "INPUTS_PUSH_CONTAINER_IMAGE" in env
     
-    def test_export_plugins_environment_variables_no_push(self, setup_test_env, monkeypatch, tmp_path):
+    def test_export_plugins_environment_variables_no_push(self, make_config, setup_test_env):
         """Test that environment variables are correctly set when push_images is False."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
+        config = make_config(
+            registry_url="quay.io",
+            registry_namespace="test-namespace"
+        )
         
-        # Create config
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        config.registry_url = "quay.io"
-        config.registry_namespace = "test-namespace"
-        
+        tmp_path = setup_test_env["tmp_path"]
         output_dir = str(tmp_path / "output")
         
-        # Mock the script path and plugins list to exist
         with patch.object(Path, "exists", return_value=True):
             with patch("os.path.exists", return_value=True):
                 with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
@@ -780,10 +615,8 @@ class TestExportPlugins:
                             
                             _result = config.export_plugins(output_dir, push_images=False)
                             
-                            # Get the env dict that was passed
                             env = mock_run_cmd.call_args[1]["env"]
                             
-                            # Verify required environment variables
                             assert env["INPUTS_SCALPRUM_CONFIG_FILE_NAME"] == "scalprum-config.json"
                             assert env["INPUTS_SOURCE_OVERLAY_FOLDER_NAME"] == "overlay"
                             assert env["INPUTS_SOURCE_PATCH_FILE_NAME"] == "patch"
@@ -796,23 +629,15 @@ class TestExportPlugins:
                             assert str((tmp_path / "output").absolute()) in env["INPUTS_DESTINATION"]
                             assert "plugins-list.yaml" in env["INPUTS_PLUGINS_FILE"]
     
-    def test_export_plugins_environment_variables_with_push(self, setup_test_env, monkeypatch, tmp_path):
+    def test_export_plugins_environment_variables_with_push(self, make_config, setup_test_env):
         """Test that environment variables are correctly set when push_images is True."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
+        config = make_config(
+            registry_url="quay.io",
+            registry_namespace="test-namespace"
+        )
         
-        # Create config
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        config.registry_url = "quay.io"
-        config.registry_namespace = "test-namespace"
+        output_dir = str(setup_test_env["tmp_path"] / "output")
         
-        output_dir = str(tmp_path / "output")
-        
-        # Mock the script path and plugins list to exist
         with patch.object(Path, "exists", return_value=True):
             with patch("os.path.exists", return_value=True):
                 with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
@@ -823,29 +648,18 @@ class TestExportPlugins:
                             
                             _result = config.export_plugins(output_dir, push_images=True)
                             
-                            # Get the env dict that was passed
                             env = mock_run_cmd.call_args[1]["env"]
-                            
-                            # Verify INPUTS_PUSH_CONTAINER_IMAGE is set to "true"
                             assert env["INPUTS_PUSH_CONTAINER_IMAGE"] == "true"
     
-    def test_export_plugins_default_registry_values(self, setup_test_env, monkeypatch, tmp_path):
+    def test_export_plugins_default_registry_values(self, make_config, setup_test_env):
         """Test that default values are used when registry_url or registry_namespace are None."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
+        config = make_config(
+            registry_url=None,
+            registry_namespace=None
+        )
         
-        # Create config without registry settings
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        config.registry_url = None
-        config.registry_namespace = None
+        output_dir = str(setup_test_env["tmp_path"] / "output")
         
-        output_dir = str(tmp_path / "output")
-        
-        # Mock the script path and plugins list to exist
         with patch.object(Path, "exists", return_value=True):
             with patch("os.path.exists", return_value=True):
                 with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
@@ -856,54 +670,31 @@ class TestExportPlugins:
                             
                             _result = config.export_plugins(output_dir, push_images=False)
                             
-                            # Get the env dict that was passed
                             env = mock_run_cmd.call_args[1]["env"]
-                            
-                            # Verify default values are used
                             assert env["INPUTS_IMAGE_REPOSITORY_PREFIX"] == "localhost/default"
     
-    def test_export_plugins_script_not_found(self, setup_test_env, monkeypatch, tmp_path):
+    def test_export_plugins_script_not_found(self, make_config, setup_test_env):
         """Test that export_plugins returns False when script doesn't exist."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
+        config = make_config()
         
-        # Create config
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
+        output_dir = str(setup_test_env["tmp_path"] / "output")
         
-        output_dir = str(tmp_path / "output")
-        
-        # Mock script path to not exist
         with patch.object(Path, "exists", return_value=False):
             with patch.object(config, "logger") as mock_logger:
                 result = config.export_plugins(output_dir, push_images=False)
                 
-                # Verify result
                 assert result is False
                 
-                # Verify error was logged
                 mock_logger.error.assert_called_once()
                 error_msg = mock_logger.error.call_args[0][0]
                 assert "Script not found" in error_msg
     
-    def test_export_plugins_no_plugins_list(self, setup_test_env, monkeypatch, tmp_path):
+    def test_export_plugins_no_plugins_list(self, make_config, setup_test_env):
         """Test that export_plugins returns False when plugins-list.yaml doesn't exist."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
+        config = make_config()
         
-        # Create config
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
+        output_dir = str(setup_test_env["tmp_path"] / "output")
         
-        output_dir = str(tmp_path / "output")
-        
-        # Mock: script exists but plugins-list.yaml doesn't
         original_path_exists = Path.exists
         
         def path_exists_side_effect(path_obj):
@@ -921,30 +712,20 @@ class TestExportPlugins:
                 with patch.object(config, "logger") as mock_logger:
                     result = config.export_plugins(output_dir, push_images=False)
                     
-                    # Verify result
                     assert result is False
                     
-                    # Verify error was logged
                     error_calls = [call[0][0] for call in mock_logger.error.call_args_list]
                     assert any("No plugins file found" in str(call) for call in error_calls)
     
-    def test_export_plugins_script_fails(self, setup_test_env, monkeypatch, tmp_path):
+    def test_export_plugins_script_fails(self, make_config, setup_test_env):
         """Test that export_plugins returns False when script returns non-zero exit code."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
+        config = make_config(
+            registry_url="quay.io",
+            registry_namespace="test-namespace"
+        )
         
-        # Create config
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        config.registry_url = "quay.io"
-        config.registry_namespace = "test-namespace"
+        output_dir = str(setup_test_env["tmp_path"] / "output")
         
-        output_dir = str(tmp_path / "output")
-        
-        # Mock run_command_with_streaming to return failure
         with patch.object(Path, "exists", return_value=True):
             with patch("os.path.exists", return_value=True):
                 with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
@@ -954,30 +735,20 @@ class TestExportPlugins:
                             
                             result = config.export_plugins(output_dir, push_images=False)
                             
-                            # Verify result
                             assert result is False
                             
-                            # Verify error was logged with exit code
                             error_calls = [call[0][0] for call in mock_logger.error.call_args_list]
                             assert any("exit code 1" in str(call) for call in error_calls)
     
-    def test_export_plugins_has_failures(self, setup_test_env, monkeypatch, tmp_path):
+    def test_export_plugins_has_failures(self, make_config, setup_test_env):
         """Test that export_plugins returns False when display_export_results indicates failures."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
+        config = make_config(
+            registry_url="quay.io",
+            registry_namespace="test-namespace"
+        )
         
-        # Create config
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        config.registry_url = "quay.io"
-        config.registry_namespace = "test-namespace"
+        output_dir = str(setup_test_env["tmp_path"] / "output")
         
-        output_dir = str(tmp_path / "output")
-        
-        # Mock: script succeeds but display_export_results indicates failures
         with patch.object(Path, "exists", return_value=True):
             with patch("os.path.exists", return_value=True):
                 with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
@@ -985,32 +756,21 @@ class TestExportPlugins:
                         with patch("src.rhdh_dynamic_plugin_factory.config.load_dotenv"):
                             with patch.object(config, "logger") as mock_logger:
                                 mock_run_cmd.return_value = 0
-                                mock_display.return_value = True  # Has failures
+                                mock_display.return_value = True
                                 
                                 result = config.export_plugins(output_dir, push_images=False)
                                 
-                                # Verify result
                                 assert result is False
                                 
-                                # Verify error was logged
                                 error_calls = [call[0][0] for call in mock_logger.error.call_args_list]
                                 assert any("completed with failures" in str(call) for call in error_calls)
     
-    def test_export_plugins_exception(self, setup_test_env, monkeypatch, tmp_path):
+    def test_export_plugins_exception(self, make_config, setup_test_env):
         """Test that export_plugins handles exceptions gracefully."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
+        config = make_config()
         
-        # Create config
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
+        output_dir = str(setup_test_env["tmp_path"] / "output")
         
-        output_dir = str(tmp_path / "output")
-        
-        # Mock run_command_with_streaming to raise an exception
         with patch.object(Path, "exists", return_value=True):
             with patch("os.path.exists", return_value=True):
                 with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
@@ -1020,36 +780,25 @@ class TestExportPlugins:
                             
                             result = config.export_plugins(output_dir, push_images=False)
                             
-                            # Verify result
                             assert result is False
                             
-                            # Verify error was logged
                             mock_logger.error.assert_called()
                             error_msg = mock_logger.error.call_args[0][0]
                             assert "Failed to run export script" in error_msg
                             assert "Test exception" in error_msg
     
-    def test_export_plugins_custom_env_file(self, setup_test_env, monkeypatch, tmp_path):
+    def test_export_plugins_custom_env_file(self, make_config, setup_test_env):
         """Test that export_plugins loads custom .env file from config directory."""
-        monkeypatch.setenv("RHDH_CLI_VERSION", "1.7.2")
-        monkeypatch.setenv("WORKSPACE_PATH", ".")
+        config = make_config(
+            registry_url="quay.io",
+            registry_namespace="test-namespace"
+        )
         
-        # Create config
-        config = PluginFactoryConfig()
-        config.config_dir = setup_test_env["config_dir"]
-        config.repo_path = setup_test_env["source_dir"]
-        config.rhdh_cli_version = "1.7.2"
-        config.workspace_path = "."
-        config.registry_url = "quay.io"
-        config.registry_namespace = "test-namespace"
-        
-        # Create a custom .env file in config directory
         custom_env = Path(setup_test_env["config_dir"]) / ".env"
         custom_env.write_text("CUSTOM_VAR=custom_value\n")
         
-        output_dir = str(tmp_path / "output")
+        output_dir = str(setup_test_env["tmp_path"] / "output")
         
-        # Track load_dotenv calls
         with patch.object(Path, "exists", return_value=True):
             with patch("os.path.exists", return_value=True):
                 with patch("src.rhdh_dynamic_plugin_factory.config.run_command_with_streaming") as mock_run_cmd:
@@ -1061,10 +810,8 @@ class TestExportPlugins:
                                 
                                 _result = config.export_plugins(output_dir, push_images=False)
                                 
-                                # Verify load_dotenv was called
                                 assert mock_load_dotenv.call_count >= 1
                                 
-                                # Verify debug log about loading custom env
                                 debug_calls = [call[0][0] for call in mock_logger.debug.call_args_list]
                                 assert any(".env" in str(call) for call in debug_calls)
 

--- a/tests/test_plugin_list_config.py
+++ b/tests/test_plugin_list_config.py
@@ -4,8 +4,6 @@ Unit tests for PluginListConfig class.
 Tests the plugin list configuration loading and management.
 """
 
-from pathlib import Path
-
 import yaml
 import pytest
 


### PR DESCRIPTION
## Description

- Updated the default `repo-path` path from `/workspace` to `/source` for better clarity as not to confuse it with the `workspace-path`
- Added a troubleshooting section for common issues (including a new issue I noticed with `quay.io` publishing when repository does not exist)
- Fixed some type issues in the `PluginFactoryConfig` and updated tests accordingly
- Cleaned up and pinned dependencies
## Which issue(s) does this PR fix

- Partially fixes [RHIDP-11337](https://issues.redhat.com/browse/RHIDP-11337)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [x] GitHub Actions are completed and successful
- [x] Tests are updated and passing
- [x] Documentation is updated

## How to test changes / Special notes to the reviewer
