### PR TITLE
chore: update build/publish workflow so e2e tests use older images

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -158,6 +158,40 @@ jobs:
     if: needs.check.outputs.should_skip == 'true'
     runs-on: ubuntu-latest
     steps:
+      - name: Save PR metadata (build skipped)
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+          PRIMARY_TAG="pr-${PR_NUMBER}"
+          ALL_TAGS="${PRIMARY_TAG},pr-${PR_NUMBER}-${SHORT_SHA}"
+
+          mkdir -p /tmp/pr-metadata
+          ALL_TAGS_JSON=$(echo "${ALL_TAGS}" | tr ',' '\n' | jq -R . | jq -s .)
+          cat > /tmp/pr-metadata/pr-info.json << EOF
+          {
+            "pr_number": "${PR_NUMBER}",
+            "commit_sha": "${COMMIT_SHA}",
+            "short_sha": "${SHORT_SHA}",
+            "primary_tag": "${PRIMARY_TAG}",
+            "all_tags": ${ALL_TAGS_JSON},
+            "platforms": ["linux/amd64", "linux/arm64"],
+            "build_skipped": true
+          }
+          EOF
+
+          echo "Generated PR metadata (build skipped):"
+          cat /tmp/pr-metadata/pr-info.json
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: pr-metadata
+          path: /tmp/pr-metadata/pr-info.json
+          retention-days: 7
+          if-no-files-found: error
+
       - name: Build Skipped Summary
         env:
           SKIP_REASON: ${{ needs.check.outputs.skip_reason }}

--- a/.github/workflows/pr-publish.yaml
+++ b/.github/workflows/pr-publish.yaml
@@ -80,15 +80,19 @@ jobs:
             exit 1
           fi
           
+          BUILD_SKIPPED=$(jq -r '.build_skipped // "false"' /tmp/pr-metadata/pr-info.json)
+
           echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
           echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
           echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
           echo "primary_tag=${PRIMARY_TAG}" >> $GITHUB_OUTPUT
           echo "all_tags=${ALL_TAGS}" >> $GITHUB_OUTPUT
-          
+          echo "build_skipped=${BUILD_SKIPPED}" >> $GITHUB_OUTPUT
+
           echo "PR Number: $PR_NUMBER"
           echo "Commit SHA: $COMMIT_SHA"
           echo "Primary Tag: $PRIMARY_TAG"
+          echo "Build Skipped: $BUILD_SKIPPED"
 
       - name: Upload PR metadata for E2E tests
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -99,6 +103,7 @@ jobs:
           if-no-files-found: error
 
       - name: Download amd64 container artifact
+        if: steps.pr-info.outputs.build_skipped != 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: container-image-pr-${{ steps.pr-info.outputs.pr_number }}-amd64
@@ -107,6 +112,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download arm64 container artifact
+        if: steps.pr-info.outputs.build_skipped != 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: container-image-pr-${{ steps.pr-info.outputs.pr_number }}-arm64
@@ -115,10 +121,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
+        if: steps.pr-info.outputs.build_skipped != 'true'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Login to Quay
-        if: env.HAS_QUAY_AUTH == 'true'
+        if: steps.pr-info.outputs.build_skipped != 'true' && env.HAS_QUAY_AUTH == 'true'
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -126,7 +133,7 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Load, push images and create manifest
-        if: env.HAS_QUAY_AUTH == 'true'
+        if: steps.pr-info.outputs.build_skipped != 'true' && env.HAS_QUAY_AUTH == 'true'
         id: push
         continue-on-error: true
         env:
@@ -201,7 +208,7 @@ jobs:
           echo "pushed_tags=${ALL_TAGS}" >> $GITHUB_OUTPUT
 
       - name: Clean up architecture-specific tags
-        if: env.HAS_QUAY_AUTH == 'true' && steps.push.outcome == 'success' && env.QUAY_OAUTH_TOKEN != ''
+        if: steps.pr-info.outputs.build_skipped != 'true' && env.HAS_QUAY_AUTH == 'true' && steps.push.outcome == 'success' && env.QUAY_OAUTH_TOKEN != ''
         env:
           ALL_TAGS: ${{ steps.pr-info.outputs.all_tags }}
           QUAY_OAUTH_TOKEN: ${{ secrets.QUAY_OAUTH_TOKEN }}
@@ -241,6 +248,7 @@ jobs:
           BUILD_RUN_ID: ${{ github.event.workflow_run.id }}
           PUBLISH_RUN_ID: ${{ github.run_id }}
           PUSH_OUTCOME: ${{ steps.push.outcome }}
+          BUILD_SKIPPED: ${{ steps.pr-info.outputs.build_skipped }}
         with:
           script: |
             const prNumber = parseInt(process.env.PR_NUMBER);
@@ -251,13 +259,27 @@ jobs:
             const registry = process.env.REGISTRY;
             const image = process.env.REGISTRY_IMAGE;
             const pushOutcome = process.env.PUSH_OUTCOME;
-            
+            const buildSkipped = process.env.BUILD_SKIPPED;
+
             const prTag = `pr-${prNumber}`;
             const prShaTag = `pr-${prNumber}-${shortSha}`;
-            
+
             let body;
-            
-            if (pushOutcome === 'success') {
+
+            if (buildSkipped === 'true') {
+              body = `## Container Image Publish Skipped
+
+            The PR build was skipped (only non-build files were changed). No new image was published.
+
+            E2E tests will run against the existing image: \`${registry}/${image}:${prTag}\`
+
+            ### Traceability
+
+            - **Build:** [PR Build #${buildRunId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${buildRunId}) (skipped)
+            - **Publish:** [PR Publish #${publishRunId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${publishRunId}) (skipped)
+            - **Commit:** \`${shortSha}\`
+            `;
+            } else if (pushOutcome === 'success') {
               const expirationDate = new Date();
               expirationDate.setDate(expirationDate.getDate() + 14);
               const expirationStr = expirationDate.toLocaleDateString('en-US', {
@@ -265,47 +287,47 @@ jobs:
                 month: 'long',
                 day: 'numeric'
               });
-              
+
               body = `## Container Image Published
-            
+
             Multi-platform container images are now available.
-            
+
             | Tag | Image | Platforms |
             |-----|-------|-----------|
             | \`${prTag}\` | \`${registry}/${image}:${prTag}\` | linux/amd64, linux/arm64 |
             | \`${prShaTag}\` | \`${registry}/${image}:${prShaTag}\` | linux/amd64, linux/arm64 |
-            
+
             **Expires:** ${expirationStr}
-            
+
             ### Pull Commands
-            
+
             \`\`\`bash
             # Multi-platform (auto-selects correct architecture)
             podman pull ${registry}/${image}:${prTag}
-            
+
             # Or with specific commit SHA
             podman pull ${registry}/${image}:${prShaTag}
             \`\`\`
-            
+
             ### Traceability
-            
+
             - **Build:** [PR Build #${buildRunId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${buildRunId})
             - **Publish:** [PR Publish #${publishRunId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${publishRunId})
             - **Commit:** \`${shortSha}\`
             `;
             } else {
               body = `## Container Image Publish Failed
-            
+
             The container image publish step failed. Please check the workflow logs for details.
-            
+
             ### Traceability
-            
+
             - **Build:** [PR Build #${buildRunId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${buildRunId})
             - **Publish:** [PR Publish #${publishRunId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${publishRunId}) (failed)
             - **Commit:** \`${shortSha}\`
             `;
             }
-            
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -345,6 +367,20 @@ jobs:
           echo "- **Triggered by:** [PR Build #${WORKFLOW_RUN_ID}](${SERVER_URL}/${REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID})" >> $GITHUB_STEP_SUMMARY
           echo "- **Commit:** \`${SHORT_SHA}\`" >> $GITHUB_STEP_SUMMARY
 
+      - name: Build Skipped Summary
+        if: steps.pr-info.outputs.build_skipped == 'true'
+        env:
+          PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
+          SHORT_SHA: ${{ steps.pr-info.outputs.short_sha }}
+        run: |
+          echo "## PR Image Publish Skipped (Build Skipped)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The PR build was skipped — only non-build files were changed." >> $GITHUB_STEP_SUMMARY
+          echo "No new image was published. E2E tests will use the existing \`pr-${PR_NUMBER}\` image." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **PR Number**: #${PR_NUMBER}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit SHA**: \`${SHORT_SHA}\`" >> $GITHUB_STEP_SUMMARY
+
       - name: No Auth Summary
         if: env.HAS_QUAY_AUTH != 'true'
         env:
@@ -359,7 +395,7 @@ jobs:
           echo "- **Commit SHA**: \`${SHORT_SHA}\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Publish Failed Summary
-        if: env.HAS_QUAY_AUTH == 'true' && steps.push.outcome != 'success'
+        if: steps.pr-info.outputs.build_skipped != 'true' && env.HAS_QUAY_AUTH == 'true' && steps.push.outcome != 'success'
         env:
           PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
           SHORT_SHA: ${{ steps.pr-info.outputs.short_sha }}
@@ -380,7 +416,7 @@ jobs:
           echo "- **Commit:** \`${SHORT_SHA}\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Fail workflow if publish failed
-        if: env.HAS_QUAY_AUTH == 'true' && steps.push.outcome != 'success'
+        if: steps.pr-info.outputs.build_skipped != 'true' && env.HAS_QUAY_AUTH == 'true' && steps.push.outcome != 'success'
         run: |
           echo "Publish step failed. Failing workflow."
           exit 1


### PR DESCRIPTION
## Description

Updates build/publish workflows so e2e tests will still use older images if build is skipped

## Which issue(s) does this PR fix

- Fixes #

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Tests are updated and passing
- [ ] Documentation is updated

## How to test changes / Special notes to the reviewer
