### PR TITLE
chore: revert back to nodejs 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/nodejs-24-minimal:9.7-1778116980
+FROM registry.access.redhat.com/ubi9/nodejs-22-minimal:9.7-1778676353
 
 # Runtime requirements and usage documentation
 LABEL description="RHDH Dynamic Plugin Factory - Build and package Backstage plugins" \


### PR DESCRIPTION
## Description

Many of the example plugins do not support node 22 yet, so reverting back from node 24
## Which issue(s) does this PR fix

- Fixes #

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Tests are updated and passing
- [ ] Documentation is updated

## How to test changes / Special notes to the reviewer
