### PR TITLE
fix: harden e2e-test workflow to install requirements.txt from trusted default branch instead

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -6,6 +6,7 @@ on:
   workflow_run:
     workflows: ["PR Publish"]
     types: [completed]
+    branches: [main, 'release-*']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
@@ -66,7 +67,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ steps.pr-info.outputs.commit_sha }}
           persist-credentials: false
 
       - name: Set up Python

--- a/.github/workflows/pr-publish.yaml
+++ b/.github/workflows/pr-publish.yaml
@@ -8,6 +8,7 @@ on:
   workflow_run:
     workflows: ["PR Build"]
     types: [completed]
+    branches: [main, 'release-*']
 
 env:
   REGISTRY: quay.io


### PR DESCRIPTION
## Description

Updates the e2e-test workflow to no longer install requirements.txt from PR branch for better security. As a tradeoff, this means PRs that update requirements.txt will need to have that merged first. Also restricts the branches where the cascaded workflows can be triggered from.

## Which issue(s) does this PR fix

- Fixes #

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Tests are updated and passing
- [ ] Documentation is updated

## How to test changes / Special notes to the reviewer
